### PR TITLE
Epic: code format and small tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,741 @@
+root = true
+
+# All Files
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+## Code Analysis rules.
+### Design rules.
+dotnet_diagnostic.CA1000.severity = error # Do not declare static members on generic types
+dotnet_diagnostic.CA1001.severity = suggestion # Types that own disposable fields should be disposable
+dotnet_diagnostic.CA1002.severity = none # Do not expose generic lists
+dotnet_diagnostic.CA1003.severity = error # [Rare] Use generic event handler instances
+dotnet_diagnostic.CA1005.severity = suggestion # [Rare] Avoid excessive parameters on generic types
+dotnet_diagnostic.CA1008.severity = warning # [ToError] Enums should have zero value
+dotnet_diagnostic.CA1010.severity = suggestion # Collections should implement generic interface
+dotnet_diagnostic.CA1012.severity = error # Abstract types should not have public constructors
+dotnet_diagnostic.CA1014.severity = none # Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1016.severity = none # Mark assemblies with AssemblyVersionAttribute
+dotnet_diagnostic.CA1017.severity = none # Mark assemblies with ComVisibleAttribute
+dotnet_diagnostic.CA1018.severity = none # Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1019.severity = error # Define accessors for attribute arguments
+dotnet_diagnostic.CA1021.severity = error # Avoid out parameters
+dotnet_diagnostic.CA1024.severity = suggestion # Use properties where appropriate
+dotnet_diagnostic.CA1027.severity = error # Mark enums with FlagsAttribute
+dotnet_diagnostic.CA1028.severity = error # Enum storage should be Int32
+dotnet_diagnostic.CA1030.severity = none # Use events where appropriate
+dotnet_diagnostic.CA1031.severity = suggestion # Do not catch general exception types
+dotnet_diagnostic.CA1032.severity = none # Implement standard exception constructors
+dotnet_diagnostic.CA1033.severity = error # Interface methods should be callable by child types
+dotnet_diagnostic.CA1034.severity = error # Nested types should not be visible
+dotnet_diagnostic.CA1036.severity = suggestion # Override methods on comparable types
+dotnet_diagnostic.CA1040.severity = suggestion # Avoid empty interfaces
+dotnet_diagnostic.CA1041.severity = error # Provide ObsoleteAttribute message
+dotnet_diagnostic.CA1043.severity = error # Use integral or string argument for indexers
+dotnet_diagnostic.CA1044.severity = warning # [ToError] Properties should not be write only
+dotnet_diagnostic.CA1045.severity = none # Do not pass types by reference
+dotnet_diagnostic.CA1046.severity = error # Do not overload operator equals on reference types
+dotnet_diagnostic.CA1047.severity = error # Do not declare protected members in sealed types
+dotnet_diagnostic.CA1050.severity = error # Declare types in namespaces
+dotnet_diagnostic.CA1051.severity = error # Do not declare visible instance fields
+dotnet_diagnostic.CA1052.severity = warning # [ToError] Static holder types should be Static or NotInheritable
+dotnet_diagnostic.CA1053.severity = error # Static holder types should not have default constructors
+dotnet_diagnostic.CA1054.severity = none # URI parameters should not be strings
+dotnet_diagnostic.CA1055.severity = none # URI return values should not be strings
+dotnet_diagnostic.CA1056.severity = none # URI properties should not be strings
+dotnet_diagnostic.CA1058.severity = suggestion # Types should not extend certain base types
+dotnet_diagnostic.CA1060.severity = none # Move P/Invokes to NativeMethods class
+dotnet_diagnostic.CA1061.severity = error # Do not hide base class methods
+dotnet_diagnostic.CA1062.severity = none # Validate arguments of public methods
+dotnet_diagnostic.CA1063.severity = warning # Implement IDisposable correctly
+dotnet_diagnostic.CA1064.severity = error # Exceptions should be public
+dotnet_diagnostic.CA1065.severity = warning # Do not raise exceptions in unexpected locations
+dotnet_diagnostic.CA1066.severity = suggestion # Implement IEquatable when overriding Equals
+dotnet_diagnostic.CA1067.severity = suggestion # Override Equals when implementing IEquatable
+dotnet_diagnostic.CA1068.severity = warning # CancellationToken parameters must come last
+dotnet_diagnostic.CA1069.severity = error # Enums should not have duplicate values
+dotnet_diagnostic.CA1070.severity = none # [Rare] Do not declare event fields as virtual
+
+### Globalization rules.
+dotnet_diagnostic.CA1303.severity = none # Do not pass literals as localized parameters
+dotnet_diagnostic.CA1304.severity = suggestion # Specify CultureInfo
+dotnet_diagnostic.CA1305.severity = suggestion # Specify IFormatProvider
+dotnet_diagnostic.CA1307.severity = suggestion # Specify StringComparison for clarity
+dotnet_diagnostic.CA1308.severity = suggestion # Normalize strings to uppercase
+dotnet_diagnostic.CA1303.severity = suggestion # Use ordinal StringComparison
+dotnet_diagnostic.CA1310.severity = suggestion # Specify StringComparison for correctness
+dotnet_diagnostic.CA2101.severity = none # Specify marshalling for P/Invoke string arguments
+
+### Maintainability rules.
+dotnet_diagnostic.CA1501.severity = suggestion # Avoid excessive inheritance (A type is more than four levels deep in its inheritance hierarchy.)
+
+# cyclomatic complexity = the number of edges - the number of nodes + 1
+dotnet_diagnostic.CA1502.severity = warning # Avoid excessive complexity
+dotnet_diagnostic.CA1505.severity = none # Avoid unmaintainable code (disabled for now. No measure configuration available)
+
+# This rule measures class coupling by counting the number of unique type references that a type or method contains.
+dotnet_diagnostic.CA1506.severity = warning # Avoid excessive class coupling
+dotnet_diagnostic.CA1507.severity = warning # Use nameof in place of string
+dotnet_diagnostic.CA1508.severity = warning # Avoid dead conditional code
+dotnet_diagnostic.CA1509.severity = warning # Invalid entry in code metrics configuration file
+
+### Naming rules.
+dotnet_diagnostic.CA1700.severity = error # Do not name enum values 'Reserved'
+dotnet_diagnostic.CA1707.severity = none # Identifiers should not contain underscores
+dotnet_diagnostic.CA1708.severity = suggestion # Identifiers should differ by more than case
+dotnet_diagnostic.CA1710.severity = suggestion # Identifiers should have correct suffix
+dotnet_diagnostic.CA1711.severity = warning # Identifiers should not have incorrect suffix
+dotnet_code_quality.CA1711.allowed_suffixes = Collection|Queue|Stream # must be reviewed.
+dotnet_diagnostic.CA1712.severity = error # Do not prefix enum values with type name
+dotnet_diagnostic.CA1713.severity = none # Events should not have before or after prefix
+dotnet_diagnostic.CA1714.severity = warning # Flags enums should have plural names
+dotnet_diagnostic.CA1715.severity = warning # Identifiers should have correct prefix
+dotnet_diagnostic.CA1716.severity = none # Identifiers should not match keywords
+dotnet_diagnostic.CA1717.severity = warning # Only FlagsAttribute enums should have plural names
+dotnet_diagnostic.CA1720.severity = error # Identifiers should not contain type names
+dotnet_diagnostic.CA1721.severity = warning # Property names should not match get methods
+dotnet_diagnostic.CA1724.severity = warning # Type names should not match namespaces
+dotnet_diagnostic.CA1725.severity = error # Parameter names should match base declaration
+dotnet_diagnostic.CA1727.severity = suggestion # Use PascalCase for named placeholders
+
+### Performance rules.
+dotnet_diagnostic.CA1802.severity = warning # Use Literals Where Appropriate
+dotnet_diagnostic.CA1805.severity = suggestion # Do not initialize unnecessarily.
+dotnet_diagnostic.CA1806.severity = suggestion # Do not ignore method results
+dotnet_diagnostic.CA1810.severity = suggestion # Initialize reference type static fields inline
+dotnet_diagnostic.CA1812.severity = none # Avoid uninstantiated internal classes
+dotnet_diagnostic.CA1813.severity = error # Avoid unsealed attributes
+dotnet_diagnostic.CA1814.severity = suggestion # Prefer jagged arrays over multidimensional
+dotnet_diagnostic.CA1815.severity = suggestion # Override equals and operator equals on value types
+dotnet_diagnostic.CA1819.severity = none # Properties should not return arrays
+dotnet_diagnostic.CA1820.severity = suggestion # Test for empty strings using string length
+dotnet_diagnostic.CA1821.severity = warning # Remove empty finalizers
+dotnet_diagnostic.CA1822.severity = warning # Mark members as static
+dotnet_diagnostic.CA1823.severity = warning # Avoid unused private fields
+dotnet_diagnostic.CA1824.severity = none # Mark assemblies with NeutralResourcesLanguageAttribute
+dotnet_diagnostic.CA1825.severity = warning # Avoid zero-length array allocations
+dotnet_diagnostic.CA1826.severity = suggestion # Use property instead of Linq Enumerable method
+dotnet_diagnostic.CA1827.severity = suggestion # Do not use Count/LongCount when Any can be used
+dotnet_diagnostic.CA1828.severity = suggestion # Do not use CountAsync/LongCountAsync when AnyAsync can be used
+dotnet_diagnostic.CA1829.severity = suggestion # Use Length/Count property instead of Enumerable.Count method
+dotnet_diagnostic.CA1830.severity = suggestion # Prefer strongly-typed Append and Insert method overloads on StringBuilder.
+dotnet_diagnostic.CA1831.severity = suggestion # Use AsSpan instead of Range-based indexers for string when appropriate
+dotnet_diagnostic.CA1832.severity = suggestion # Use AsSpan or AsMemory instead of Range-based indexers for getting ReadOnlySpan or ReadOnlyMemory portion of an array
+dotnet_diagnostic.CA1833.severity = suggestion # Use AsSpan or AsMemory instead of Range-based indexers for getting Span or Memory portion of an array
+dotnet_diagnostic.CA1834.severity = suggestion # Use StringBuilder.Append(char) for single character strings
+dotnet_diagnostic.CA1835.severity = suggestion # Prefer the memory-based overloads of ReadAsync/WriteAsync methods in stream-based classes
+dotnet_diagnostic.CA1836.severity = suggestion # Prefer IsEmpty over Count when available
+dotnet_diagnostic.CA1837.severity = none # [Rare] Use Environment.ProcessId instead of Process.GetCurrentProcess().Id
+dotnet_diagnostic.CA1838.severity = none # [Rare] Avoid StringBuilder parameters for P/Invokes
+dotnet_diagnostic.CA1839.severity = none # [Rare] Use Environment.ProcessPath instead of Process.GetCurrentProcess().MainModule.FileName
+dotnet_diagnostic.CA1840.severity = none # [Rare] Use Environment.CurrentManagedThreadId instead of Thread.CurrentThread.ManagedThreadId
+dotnet_diagnostic.CA1841.severity = suggestion # Prefer Dictionary Contains methods
+dotnet_diagnostic.CA1842.severity = suggestion # Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1843.severity = suggestion # Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1844.severity = none # [Rare] Provide memory-based overrides of async methods when subclassing 'Stream'
+dotnet_diagnostic.CA1845.severity = suggestion # Use span-based 'string.Concat'
+dotnet_diagnostic.CA1846.severity = suggestion # Prefer AsSpan over Substring
+dotnet_diagnostic.CA1847.severity = suggestion # Use string.Contains(char) instead of string.Contains(string) with single characters
+dotnet_diagnostic.CA1848.severity = suggestion # Use the LoggerMessage delegates
+dotnet_diagnostic.CA1849.severity = suggestion # Call async methods when in an async method
+dotnet_diagnostic.CA1850.severity = suggestion # Prefer static HashData method over ComputeHash
+dotnet_diagnostic.CA1851.severity = warning # Possible multiple enumerations of IEnumerable collection
+dotnet_diagnostic.CA1854.severity = suggestion # Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+
+### Reliability rules.
+dotnet_diagnostic.CA2000.severity = suggestion # Dispose objects before losing scope
+dotnet_diagnostic.CA2002.severity = error # Do not lock on objects with weak identity
+dotnet_diagnostic.CA2007.severity = none # Do not directly await a Task
+dotnet_diagnostic.CA2008.severity = none # Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2009.severity = warning # Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2011.severity = warning # Do not assign property within its setter
+dotnet_diagnostic.CA2012.severity = warning # Use ValueTasks correctly
+dotnet_diagnostic.CA2013.severity = warning # Do not use ReferenceEquals with value types
+dotnet_diagnostic.CA2014.severity = warning # [Rare] Do not use stackalloc in loops
+dotnet_diagnostic.CA2015.severity = warning # [Rare] Do not define finalizers for types derived from MemoryManager<T>
+dotnet_diagnostic.CA2016.severity = warning # Forward the CancellationToken parameter to methods that take one
+dotnet_diagnostic.CA2017.severity = error # Parameter count mismatch
+dotnet_diagnostic.CA2018.severity = suggestion # [Rare] The count argument to Buffer.BlockCopy should specify the number of bytes to copy
+
+### Usage rules.
+dotnet_diagnostic.CA1801.severity = warning # Review unused parameters
+dotnet_diagnostic.CA1818.severity = warning # Call GC.SuppressFinalize correctly
+dotnet_diagnostic.CA2200.severity = warning # Rethrow to preserve stack details
+dotnet_diagnostic.CA2201.severity = suggestion # [ToError] Do not raise reserved exception types
+dotnet_diagnostic.CA2207.severity = warning # Initialize value type static fields inline
+dotnet_diagnostic.CA2208.severity = error # Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2211.severity = warning # Non-constant fields should not be visible
+dotnet_diagnostic.CA2213.severity = none # Disposable fields should be disposed
+dotnet_diagnostic.CA2214.severity = error # Do not call overridable methods in constructors
+dotnet_diagnostic.CA2215.severity = error # Dispose methods should call base class dispose
+dotnet_diagnostic.CA2216.severity = error # Disposable types should declare finalizer
+dotnet_diagnostic.CA2217.severity = error # Do not mark enums with FlagsAttribute
+dotnet_diagnostic.CA2218.severity = error # Override GetHashCode on overriding Equals
+dotnet_diagnostic.CA2219.severity = warning # Do not raise exceptions in exception clauses
+dotnet_diagnostic.CA2224.severity = suggestion # Override Equals on overloading operator equals
+dotnet_diagnostic.CA2225.severity = suggestion # Operator overloads have named alternates
+dotnet_diagnostic.CA2226.severity = warning # Operators should have symmetrical overloads
+dotnet_diagnostic.CA2227.severity = none # Collection properties should be read only
+dotnet_diagnostic.CA2229.severity = none # Implement serialization constructors
+dotnet_diagnostic.CA2231.severity = warning # Overload operator equals on overriding ValueType.Equals
+dotnet_diagnostic.CA2234.severity = none # Pass System.Uri objects instead of strings
+dotnet_diagnostic.CA2235.severity = none # Mark all non-serializable fields
+dotnet_diagnostic.CA2237.severity = none # Mark ISerializable types with SerializableAttribute
+dotnet_diagnostic.CA2241.severity = error # Provide correct arguments to formatting methods
+dotnet_diagnostic.CA2242.severity = none # Test for NaN correctly
+dotnet_diagnostic.CA2243.severity = none # [Rare] Attribute string literals should parse correctly
+dotnet_diagnostic.CA2244.severity = error # Do not duplicate indexed element initializations
+dotnet_diagnostic.CA2245.severity = error # Do not assign a property to itself
+dotnet_diagnostic.CA2246.severity = error # Do not assign a symbol and its member in the same statement
+dotnet_diagnostic.CA2247.severity = warning # Use TaskCreationOptions enum instead of TaskContinuationOptions enum
+dotnet_diagnostic.CA2248.severity = error # Provide correct enum argument to Enum.HasFlag
+dotnet_diagnostic.CA2249.severity = warning # Consider using String.Contains instead of String.IndexOf
+dotnet_diagnostic.CA2250.severity = suggestion # Use ThrowIfCancellationRequested
+dotnet_diagnostic.CA2251.severity = warning # Use String.Equals over String.Compare
+dotnet_diagnostic.CA2252.severity = suggestion # Opt in to preview features before using them
+dotnet_diagnostic.CA2253.severity = suggestion # Named placeholders should not be numeric values
+dotnet_diagnostic.CA2254.severity = suggestion # Template should be a static expression
+dotnet_diagnostic.CA2255.severity = none # [Rare] The ModuleInitializer attribute should not be used in libraries
+dotnet_diagnostic.CA2256.severity = none # [Rare] DynamicInterfaceCastableImplementation-attributed interface
+dotnet_diagnostic.CA2257.severity = none # [Rare] 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+dotnet_diagnostic.CA2258.severity = none # [Rare] 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+
+### Code style rules.
+dotnet_diagnostic.IDE0003.severity = error # Remove this and me.
+dotnet_diagnostic.IDE0009.severity = none # Add this and me.
+dotnet_diagnostic.IDE0049.severity = warning # Use language keywords instead of framework type names for type references
+dotnet_diagnostic.IDE0010.severity = suggestion # Add missing cases to switch statement
+dotnet_diagnostic.IDE0017.severity = suggestion # Use object initializers
+dotnet_diagnostic.IDE0018.severity = suggestion # Inline variable declaration
+dotnet_diagnostic.IDE0028.severity = suggestion # Use collection initializers
+dotnet_diagnostic.IDE0032.severity = suggestion # Use auto-implemented property
+dotnet_diagnostic.IDE0033.severity = warning # Use explicitly provided tuple name
+dotnet_diagnostic.IDE0034.severity = warning # Simplify 'default' expression
+dotnet_diagnostic.IDE0037.severity = warning # Use inferred member names
+dotnet_diagnostic.IDE0039.severity = none # Use local function instead of lambda
+dotnet_diagnostic.IDE0042.severity = warning # Deconstruct variable declaration
+dotnet_diagnostic.IDE0045.severity = warning # Use conditional expression for assignment
+dotnet_diagnostic.IDE0046.severity = warning # Use conditional expression for return
+dotnet_diagnostic.IDE0054.severity = suggestion # Use compound assignment
+dotnet_diagnostic.IDE0074.severity = none # Use coalesce compound assignment
+dotnet_diagnostic.IDE0075.severity = warning # Simplify conditional expression
+dotnet_diagnostic.IDE0082.severity = warning # Convert typeof to nameof
+dotnet_diagnostic.IDE0090.severity = warning # Simplify new expression
+dotnet_diagnostic.IDE0180.severity = suggestion # Use tuple to swap values
+dotnet_diagnostic.IDE0160.severity = none # Use block-scoped namespace
+dotnet_diagnostic.IDE0161.severity = error # Use file-scoped namespace
+dotnet_diagnostic.IDE0016.severity = suggestion # Use throw expression
+dotnet_diagnostic.IDE0029.severity = none # Use coalesce expression (non-nullable types)
+dotnet_diagnostic.IDE0030.severity = warning # Use coalesce expression (nullable types)
+dotnet_diagnostic.IDE0031.severity = warning # Use null propagation
+dotnet_diagnostic.IDE0041.severity = warning # Use 'is null' check
+dotnet_diagnostic.IDE0150.severity = warning # Prefer 'null' check over type check
+dotnet_diagnostic.IDE1005.severity = warning # Use conditional delegate call
+dotnet_diagnostic.IDE0007.severity = warning # Use var instead of explicit type
+dotnet_diagnostic.IDE0008.severity = none # Use explicit type instead of var
+dotnet_diagnostic.IDE0021.severity = warning # [ToError] Use expression body for constructors
+dotnet_diagnostic.IDE0022.severity = warning # [ToError] Use expression body for methods
+dotnet_diagnostic.IDE0023.severity = error # Use expression body for conversion operators
+dotnet_diagnostic.IDE0024.severity = error # Use expression body for operators
+dotnet_diagnostic.IDE0025.severity = error # Use expression body for properties
+dotnet_diagnostic.IDE0026.severity = error # Use expression body for indexers
+dotnet_diagnostic.IDE0027.severity = error # Use expression body for accessors
+dotnet_diagnostic.IDE0053.severity = warning # Use expression body for lambdas
+dotnet_diagnostic.IDE0061.severity = error # Use expression body for local functions
+dotnet_diagnostic.IDE0019.severity = warning # Use pattern matching to avoid 'as' followed by a 'null' check
+dotnet_diagnostic.IDE0020.severity = warning # Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0038.severity = warning # Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0066.severity = warning # Use switch expression
+dotnet_diagnostic.IDE0078.severity = warning # Use pattern matching
+dotnet_diagnostic.IDE0083.severity = warning # Use pattern matching (not operator)
+dotnet_diagnostic.IDE0084.severity = warning # Use pattern matching (IsNot operator)
+dotnet_diagnostic.IDE0170.severity = warning # Simplify property pattern
+dotnet_diagnostic.IDE0011.severity = error # Add braces
+dotnet_diagnostic.IDE0063.severity = suggestion # Use simple 'using' statement
+dotnet_diagnostic.IDE0065.severity = error # 'using' directive placement
+dotnet_diagnostic.IDE0073.severity = none # Require file header
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = suggestion # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning # Remove unnecessary using directives
+dotnet_diagnostic.IDE0035.severity = warning # Remove unreachable code
+dotnet_diagnostic.IDE0051.severity = error # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = warning # Remove unread private member
+dotnet_diagnostic.IDE0058.severity = none # Remove unnecessary expression value
+dotnet_diagnostic.IDE0059.severity = none # Remove unnecessary value assignment
+dotnet_diagnostic.IDE0060.severity = error # Remove unused parameter
+dotnet_diagnostic.IDE0079.severity = warning # Remove unnecessary suppression
+dotnet_diagnostic.IDE0080.severity = warning # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0100.severity = warning # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = warning # Remove unnecessary discard
+dotnet_diagnostic.IDE1006.severity = error # Naming rule violation
+dotnet_diagnostic.IDE0072.severity = suggestion # Add missing cases to switch expression
+
+## Stylecop rules.
+### Spacing rules.
+dotnet_diagnostic.SA1000.severity = warning # The spacing around a C# keyword is incorrect.
+dotnet_diagnostic.SA1001.severity = warning # The spacing around a comma is incorrect, within a C# code file.
+dotnet_diagnostic.SA1002.severity = warning # The spacing around a semicolon is incorrect, within a C# code file.
+dotnet_diagnostic.SA1003.severity = warning # The spacing around an operator symbol is incorrect, within a C# code file.
+dotnet_diagnostic.SA1004.severity = warning # A line within a documentation header above a C# element does not begin with a single space.
+dotnet_diagnostic.SA1005.severity = warning # A single-line comment within a C# code file does not begin with a single space.
+dotnet_diagnostic.SA1006.severity = warning # A C# preprocessor-type keyword is preceded by space.
+dotnet_diagnostic.SA1007.severity = warning # The operator keyword within a C# operator overload method is not followed by any whitespace.
+dotnet_diagnostic.SA1008.severity = warning # An opening parenthesis within a C# statement is not spaced correctly.
+dotnet_diagnostic.SA1009.severity = warning # A closing parenthesis within a C# statement is not spaced correctly.
+dotnet_diagnostic.SA1010.severity = warning # An opening square bracket within a C# statement is not spaced correctly.
+dotnet_diagnostic.SA1011.severity = warning # A closing square bracket within a C# statement is not spaced correctly.
+dotnet_diagnostic.SA1012.severity = warning # An opening curly bracket within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1013.severity = warning # A closing curly bracket within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1014.severity = warning # An opening generic bracket within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1015.severity = warning # A closing generic bracket within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1016.severity = warning # An opening attribute bracket within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1017.severity = warning # A closing attribute bracket within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1018.severity = warning # A nullable type symbol within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1019.severity = warning # The spacing around a member access symbol is incorrect, within a C# code file.
+dotnet_diagnostic.SA1020.severity = warning # An increment or decrement symbol within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1021.severity = warning # A negative sign within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1022.severity = warning # A positive sign within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1023.severity = none # [Rare] A dereference symbol or an access-of symbol within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1024.severity = warning # A colon within a C# element is not spaced correctly.
+dotnet_diagnostic.SA1025.severity = warning # The code contains multiple whitespace characters in a row.
+dotnet_diagnostic.SA1026.severity = warning # An implicitly typed new array allocation within a C# code file is not spaced correctly.
+dotnet_diagnostic.SA1027.severity = none # [Conflict] The C# code contains a tab character.
+dotnet_diagnostic.SA1028.severity = warning # [ToError] A line of code ends with a space, tab, or other whitespace characters before the end of line character(s).
+
+### Readability rules.
+
+#### A call to a member from an inherited class begins with ‘base.’,
+#### and the local class does not contain an override or implementation of the member.
+dotnet_diagnostic.SA1100.severity = warning
+dotnet_diagnostic.SA1101.severity = none # [Conflict] A call to an instance member of the local class or a base class is not prefixed with ‘this.’, within a C# code file.
+dotnet_diagnostic.SA1102.severity = warning # A C# query clause does not begin on the same line as the previous clause, or on the next line.
+dotnet_diagnostic.SA1103.severity = warning # The clauses within a C# query expression are not all placed on the same line, and each clause is not placed on its own line.
+dotnet_diagnostic.SA1104.severity = warning # A clause within a C# query expression begins on the same line as the previous clause, when the previous clause spans across multiple lines.
+dotnet_diagnostic.SA1105.severity = warning # A clause within a C# query expression spans across multiple lines, and does not begin on its own line.
+dotnet_diagnostic.SA1106.severity = error # The C# code contains an extra semicolon.
+dotnet_diagnostic.SA1107.severity = error # The C# code contains more than one statement on a single line.
+dotnet_diagnostic.SA1108.severity = error # A C# statement contains a comment between the declaration of the statement and the opening curly bracket of the statement.
+dotnet_diagnostic.SA1109.severity = error # -- region --
+dotnet_diagnostic.SA1110.severity = error # Opening Parenthesis Must Be On Declaration Line
+dotnet_diagnostic.SA1111.severity = error # Closing Parenthesis Must On Line Of Last Parameter
+dotnet_diagnostic.SA1112.severity = error # Closing Parenthesis Must Be On Line Of Opening Parenthesis
+dotnet_diagnostic.SA1113.severity = error # Comma Must Be On Same Line As Previous Parameter
+dotnet_diagnostic.SA1114.severity = error # Parameter List Must Follow Declaration
+dotnet_diagnostic.SA1115.severity = error # Parameter Must Follow Comma
+dotnet_diagnostic.SA1116.severity = error # Split Parameters Must Start On Line After Declaration
+dotnet_diagnostic.SA1117.severity = error # Parameters Must Be On Same Line Or Separate Lines
+dotnet_diagnostic.SA1118.severity = warning # [ToError] Parameter Must Not Span Multiple Lines
+dotnet_diagnostic.SA1120.severity = error # The C# comment does not contain any comment text.
+dotnet_diagnostic.SA1121.severity = error # The code uses one of the basic C# types, but does not use the built-in alias for the type.
+dotnet_diagnostic.SA1122.severity = error # The C# code includes an empty string, written as “”.
+dotnet_diagnostic.SA1123.severity = error # The C# code contains a region within the body of a code element.
+dotnet_diagnostic.SA1124.severity = error # The C# code contains a region.
+dotnet_diagnostic.SA1125.severity = error # A violation of this rule occurs whenever the Nullable type has been defined without using the shorthand C# style.
+dotnet_diagnostic.SA1126.severity = none # [Disabled] A call to a member is not prefixed with the 'this.', 'base.', 'object.' or 'typename.' prefix to indicate the intended method call, within a C# code file.
+dotnet_diagnostic.SA1127.severity = error # A generic constraint on a type or method declaration is on the same line as the declaration, within a C# code file.
+dotnet_diagnostic.SA1128.severity = none # A constructor initializer is on the same line as the constructor declaration, within a C# code file.
+dotnet_diagnostic.SA1129.severity = suggestion # A value type was constructed using the syntax new T().
+dotnet_diagnostic.SA1130.severity = warning # Use lambda syntax.
+dotnet_diagnostic.SA1131.severity = warning # Use readable conditions.
+dotnet_diagnostic.SA1132.severity = error # Two or more fields were declared in the same field declaration syntax.
+dotnet_diagnostic.SA1133.severity = error # Two or more attributes appeared within the same set of square brackets.
+dotnet_diagnostic.SA1134.severity = error # An attribute is placed on the same line of code as another attribute or element.
+dotnet_diagnostic.SA1135.severity = none # [Conflict] A using directive is not qualified.
+dotnet_diagnostic.SA1136.severity = error # Multiple enum values are placed on the same line of code.
+dotnet_diagnostic.SA1137.severity = warning # Two sibling elements which each start on their own line have different levels of indentation.
+dotnet_diagnostic.SA1139.severity = warning # A cast is performed instead of using literal of a number.
+dotnet_diagnostic.SA1141.severity = warning # A ValueTuple type declaration was used instead of the preferred tuple language construct.
+dotnet_diagnostic.SA1142.severity = warning # An element of a tuple was referenced by its metadata name when an element name is available.
+
+### Ordering rules.
+dotnet_diagnostic.SA1200.severity = none # [Conflict] A C# using directive is placed outside of a namespace element.
+dotnet_diagnostic.SA1201.severity = error # An element within a C# code file is out of order in relation to the other elements in the code.
+dotnet_diagnostic.SA1202.severity = error # An element within a C# code file is out of order within regard to access level, in relation to other elements in the code.
+dotnet_diagnostic.SA1203.severity = error # A const field is placed beneath a non-const field.
+dotnet_diagnostic.SA1204.severity = error # A static element is positioned beneath an instance element of the same type.
+dotnet_diagnostic.SA1205.severity = error # The partial element does not have an access modifier defined.
+dotnet_diagnostic.SA1206.severity = error # The keywords within the declaration of an element do not follow a standard ordering scheme.
+dotnet_diagnostic.SA1207.severity = error # The keyword protected is positioned after the keyword internal within the declaration of a protected internal C# element.
+dotnet_diagnostic.SA1208.severity = error # System Using Directives Must Be Placed Before Other Using Directives
+dotnet_diagnostic.SA1209.severity = error # A using-alias directive is positioned before a regular using directive.
+dotnet_diagnostic.SA1210.severity = error # The using directives within a C# code file are not sorted alphabetically by namespace.
+dotnet_diagnostic.SA1211.severity = error # The using-alias directives within a C# code file are not sorted alphabetically by alias name.
+dotnet_diagnostic.SA1212.severity = error # A get accessor appears after a set accessor within a property or indexer.
+dotnet_diagnostic.SA1213.severity = none # [Rare] An add accessor appears after a remove accessor within an event.
+dotnet_diagnostic.SA1214.severity = error # A readonly field is positioned beneath a non-readonly field.
+dotnet_diagnostic.SA1215.severity = error # An instance readonly element is positioned beneath an instance non-readonly element of the same type.
+dotnet_diagnostic.SA1216.severity = warning # A using static directive is positioned at the wrong location (before a regular using directive or after an alias using directive).
+dotnet_diagnostic.SA1217.severity = warning # The using static directives within a C# code file are not sorted alphabetically by full type name.
+
+### Naming rules.
+dotnet_diagnostic.SA1300.severity = error # The name of a C# element does not begin with an upper-case letter.
+dotnet_diagnostic.SA1301.severity = none # [No cases]
+dotnet_diagnostic.SA1302.severity = error # The name of a C# interface does not begin with the capital letter I.
+dotnet_diagnostic.SA1303.severity = error # The name of a constant C# field must begin with an upper-case letter.
+dotnet_diagnostic.SA1304.severity = error # The name of a non-private readonly C# field must being with an upper-case letter.
+dotnet_diagnostic.SA1305.severity = warning # [ToError] The name of a field or variable in C# uses Hungarian notation.
+dotnet_diagnostic.SA1306.severity = none # [Conflict] The name of a field or variable in C# does not begin with a lower-case letter.
+dotnet_diagnostic.SA1307.severity = error # The name of a public or internal field in C# does not begin with an upper-case letter.
+dotnet_diagnostic.SA1308.severity = error # A field name in C# is prefixed with m_ or s_.
+dotnet_diagnostic.SA1309.severity = none # [Conflict] A field name in C# begins with an underscore.
+dotnet_diagnostic.SA1310.severity = none # [Conflict] A field name in C# contains an underscore.
+dotnet_diagnostic.SA1311.severity = error # The name of a static readonly field does not begin with an upper-case letter.
+dotnet_diagnostic.SA1312.severity = error # The name of a variable in C# does not begin with a lower-case letter.
+dotnet_diagnostic.SA1313.severity = error # The name of a parameter in C# does not begin with a lower-case letter.
+dotnet_diagnostic.SA1314.severity = error # The name of a C# type parameter does not begin with the capital letter T.
+dotnet_diagnostic.SA1316.severity = error # Element names within a tuple type should have the correct casing.
+
+### Maintainability rules.
+dotnet_diagnostic.SA1119.severity = suggestion # A C# statement contains parenthesis which are unnecessary and should be removed.
+dotnet_diagnostic.SA1400.severity = warning # The access modifier for a C# element has not been explicitly defined.
+dotnet_diagnostic.SA1401.severity = error # A field within a C# class has an access modifier other than private.
+dotnet_diagnostic.SA1402.severity = warning # [To Error] A C# code file contains more than one unique class.
+dotnet_diagnostic.SA1403.severity = error # A C# code file contains more than one namespace.
+dotnet_diagnostic.SA1404.severity = warning # A Code Analysis SuppressMessage attribute does not include a justification.
+dotnet_diagnostic.SA1405.severity = warning # A call to Debug.Assert in C# code does not include a descriptive message.
+dotnet_diagnostic.SA1406.severity = warning # A call to Debug.Fail in C# code does not include a descriptive message.
+dotnet_diagnostic.SA1407.severity = warning # A C# statement contains a complex arithmetic expression which omits parenthesis around operators.
+dotnet_diagnostic.SA1408.severity = warning # A C# statement contains a complex conditional expression which omits parenthesis around operators.
+dotnet_diagnostic.SA1409.severity = warning # A C# file contains code which is unnecessary and can be removed without changing the overall logic of the code.
+dotnet_diagnostic.SA1410.severity = warning # [Rare] A call to a C# anonymous method does not contain any method parameters, yet the statement still includes parenthesis.
+dotnet_diagnostic.SA1411.severity = none # [Rare] A violation of this rule occurs when unnecessary parenthesis have been used in an attribute constructor.
+dotnet_diagnostic.SA1412.severity = none # The encoding of the file is not UTF-8 with byte order mark.
+dotnet_diagnostic.SA1413.severity = warning # The last statement in a multi-line C# initializer or list is missing a trailing comma.
+dotnet_diagnostic.SA1414.severity = warning # A tuple type without element names is present in a member declaration.
+
+### Layout rules.
+dotnet_diagnostic.SA1500.severity = warning # [ToError] The opening or closing curly bracket within a C# statement, element, or expression is not placed on its own line.
+dotnet_diagnostic.SA1501.severity = warning # [ToError] A C# statement containing opening and closing curly brackets is written completely on a single line.
+dotnet_diagnostic.SA1502.severity = warning # [ToError] A C# element containing opening and closing curly brackets is written completely on a single line.
+dotnet_diagnostic.SA1503.severity = warning # [ToError] The opening and closing curly brackets for a C# statement have been omitted.
+dotnet_diagnostic.SA1504.severity = warning # All Accessors Must Be Single Line Or MultiLine
+dotnet_diagnostic.SA1505.severity = warning # [ToError] An opening curly bracket within a C# element, statement, or expression is followed by a blank line.
+dotnet_diagnostic.SA1506.severity = warning # [ToError] An element documentation header above a C# element is followed by a blank line.
+dotnet_diagnostic.SA1507.severity = warning # [ToError] The C# code contains multiple blank lines in a row.
+dotnet_diagnostic.SA1508.severity = warning # [ToError] A closing curly bracket within a C# element, statement, or expression is preceded by a blank line.
+dotnet_diagnostic.SA1509.severity = warning # [ToError] An opening curly bracket within a C# element, statement, or expression is preceded by a blank line.
+dotnet_diagnostic.SA1510.severity = warning # [ToError] Chained C# statements are separated by a blank line.
+dotnet_diagnostic.SA1511.severity = warning # [ToError] The while footer at the bottom of a do-while statement is separated from the statement by a blank line.
+dotnet_diagnostic.SA1512.severity = warning # A single-line comment within C# code is followed by a blank line.
+dotnet_diagnostic.SA1513.severity = warning # A closing curly bracket within a C# element, statement, or expression is not followed by a blank line.
+dotnet_diagnostic.SA1514.severity = warning # An element documentation header above a C# element is not preceded by a blank line.
+dotnet_diagnostic.SA1515.severity = warning # A single-line comment within C# code is not preceded by a blank line.
+dotnet_diagnostic.SA1516.severity = warning # [ToError] Adjacent C# elements are not separated by a blank line.
+dotnet_diagnostic.SA1517.severity = warning # [ToError] The code file has blank lines at the start.
+dotnet_diagnostic.SA1518.severity = none # [Conflict] The code file has blank lines at the end.
+dotnet_diagnostic.SA1519.severity = warning # [ToError] The opening and closing braces for a multi-line C# statement have been omitted.
+dotnet_diagnostic.SA1520.severity = warning # [ToError] The opening and closing braces of a chained if/else if/else construct were included for some clauses, but omitted for others.
+
+### Documentation rules.
+dotnet_diagnostic.SA0001.severity = none # XML comment analysis is disabled due to project configuration
+dotnet_diagnostic.SA1600.severity = none # A C# code element is missing a documentation header.
+dotnet_diagnostic.SA1602.severity = none # Enumeration items must be documented
+dotnet_diagnostic.SA1611.severity = none # Element parameters must be documented
+dotnet_diagnostic.SA1614.severity = none # Element parameter documentation must have text
+dotnet_diagnostic.SA1615.severity = none # Element return value must be documented
+dotnet_diagnostic.SA1616.severity = none # Element return value documentation must have text
+dotnet_diagnostic.SA1622.severity = none # Generic type parameter documentation must have text
+dotnet_diagnostic.SA1623.severity = none # Property summary documentation must match accessors
+dotnet_diagnostic.SA1627.severity = none # Documentation text must not be empty
+dotnet_diagnostic.SA1629.severity = none # Documentation text must end with a period
+dotnet_diagnostic.SA1633.severity = none # File must have header
+dotnet_diagnostic.SA1642.severity = none # Constructor summary documentation must begin with standard text
+
+### Alternative rules.
+dotnet_diagnostic.SX1101.severity = error # A call to an instance member of the local class or a base class is prefixed with this.
+dotnet_diagnostic.SX1309.severity = error # A field name does not begin with an underscore.
+dotnet_diagnostic.SX1309S.severity = none # [Conflict] A static field name does not begin with an underscore.
+
+### Other rules.
+dotnet_diagnostic.CS1591.severity = none # Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS8618.severity = none # Default value for not nullable types
+
+##########################################
+# File Extension Settings
+##########################################
+
+# XML Configuration Files
+[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Web Files
+[*.{htm,html,js,jsm,ts,tsx,css,sass,scss,less,pcss,svg,vue,svelte}]
+indent_style = space
+indent_size = 2
+
+# Bash Files
+[*.sh]
+end_of_line = lf
+
+# .NET Style Rules
+[*.{cs,csx,cake,vb,vbx}]
+# "this." and "Me." qualifiers
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
+# Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:error
+dotnet_style_readonly_field = true:error
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:suggestion
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = false:warning
+dotnet_style_prefer_conditional_expression_over_return = false:warning
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:warning
+# Null-checking preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_operator_placement_when_wrapping = beginning_of_line:error
+
+# C# Style Rules
+[*.{cs,csx,cake}]
+# 'var' preferences
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:warning
+csharp_style_expression_bodied_constructors = false:warning
+csharp_style_expression_bodied_operators = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_lambdas = when_on_single_line:error
+csharp_style_expression_bodied_local_functions = false:none
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_not_pattern = true:warning
+# Expression-level preferences
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:warning
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+# "Null" checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:error
+# Code block preferences
+csharp_prefer_braces = true:error
+csharp_prefer_simple_using_statement = true:suggestion
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:error
+# Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:error
+
+# .NET Unnecessary code rules
+[*.{cs,csx,cake,vb,vbx}]
+dotnet_code_quality_unused_parameters = all:error
+
+# C# Unnecessary code rules
+[*.{cs,csx,cake}]
+csharp_style_unused_value_expression_statement_preference = unused_local_variable:none
+csharp_style_unused_value_assignment_preference = discard_variable:none
+
+# .NET formatting rules
+[*.{cs,csx,cake,vb,vbx}]
+# Organize using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+# C# formatting rules
+[*.{cs,csx,cake}]
+# Newline options
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation options
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = no_change
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents_when_block = false
+# Spacing options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_after_comma = true
+csharp_space_before_comma = false
+csharp_space_after_dot = false
+csharp_space_before_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_around_declaration_statements = false
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+# Wrap options
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+[*.{cs,csx,cake,vb,vbx}]
+# camel_case_style - Define the camelCase style
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+# camel_case_style_prefixed - Define the camelCase style with prefix _
+dotnet_naming_style.camel_case_style_prefixed.capitalization = camel_case
+dotnet_naming_style.camel_case_style_prefixed.required_prefix = _
+# pascal_case_style - Define the PascalCase style
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# first_upper_style - The first character must start with an upper-case character
+dotnet_naming_style.first_upper_style.capitalization = first_word_upper
+# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+# disallowed_style - Anything that has this style applied is marked as disallowed
+dotnet_naming_style.disallowed_style.capitalization = pascal_case
+dotnet_naming_style.internal_error_style.capitalization = pascal_case
+dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
+dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
+# Define what we will treat as private fields.
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+# Define rule that something must begin with an underscore and be in camel case.
+dotnet_naming_style.require_underscore_prefix_and_camel_case.required_prefix = _
+dotnet_naming_style.require_underscore_prefix_and_camel_case.capitalization = camel_case
+# Appy our rule to private fields.
+dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.style = require_underscore_prefix_and_camel_case
+dotnet_naming_rule.private_fields_must_begin_with_underscore_and_be_in_camel_case.severity = warning
+# All public/protected/protected_internal constant fields must be PascalCase
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers = const
+dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds = field
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols = public_protected_constant_fields_group
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity = warning
+# All public/protected/protected_internal static readonly fields must be PascalCase
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers = static, readonly
+dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds = field
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols = public_protected_static_readonly_fields_group
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity = warning
+# All private static readonly fields must be camel_case_style_prefixed
+dotnet_naming_symbols.private_protected_static_readonly_fields_group.applicable_accessibilities = private, protected, protected_internal
+dotnet_naming_symbols.private_protected_static_readonly_fields_group.required_modifiers = static, readonly
+dotnet_naming_symbols.private_protected_static_readonly_fields_group.applicable_kinds = field
+dotnet_naming_rule.private_protected_static_readonly_fields_must_be_pascal_case_rule.symbols = private_protected_static_readonly_fields_group
+dotnet_naming_rule.private_protected_static_readonly_fields_must_be_pascal_case_rule.style = camel_case_style_prefixed
+dotnet_naming_rule.private_protected_static_readonly_fields_must_be_pascal_case_rule.severity = error
+# No other public/protected/protected_internal fields are allowed
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
+dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds = field
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols = other_public_protected_fields_group
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style = disallowed_style
+dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity = error
+# All constant fields must be PascalCase
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers = const
+dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols = stylecop_constant_fields_group
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity = warning
+# All static readonly fields must be PascalCase
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers = static, readonly
+dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols = stylecop_static_readonly_fields_group
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
+dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity = warning
+# No non-private instance fields are allowed
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols = stylecop_fields_must_be_private_group
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style = disallowed_style
+dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity = error
+# Private fields must be camelCase
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
+dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds = field
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols = stylecop_private_fields_group
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style = camel_case_style
+dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity = warning
+# Local variables must be camelCase
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
+dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds = local
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols = stylecop_local_fields_group
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style = camel_case_style
+dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity = silent
+# This rule should never fire. However, it's included for at least two purposes:
+# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
+# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
+dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds = field
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols = sanity_check_uncovered_field_case_group
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style = internal_error_style
+dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
+
+##########################################
+# Other Naming Rules
+##########################################
+
+dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
+dotnet_naming_rule.element_rule.symbols = element_group
+dotnet_naming_rule.element_rule.style = pascal_case_style
+dotnet_naming_rule.element_rule.severity = warning
+# Interfaces use PascalCase and are prefixed with uppercase 'I'
+dotnet_naming_symbols.interface_group.applicable_kinds = interface
+dotnet_naming_rule.interface_rule.symbols = interface_group
+dotnet_naming_rule.interface_rule.style = prefix_interface_with_i_style
+dotnet_naming_rule.interface_rule.severity = warning
+# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
+dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameter_rule.symbols = type_parameter_group
+dotnet_naming_rule.type_parameter_rule.style = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameter_rule.severity = warning
+# Function parameters use camelCase
+dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
+dotnet_naming_rule.parameters_rule.symbols = parameters_group
+dotnet_naming_rule.parameters_rule.style = camel_case_style
+dotnet_naming_rule.parameters_rule.severity = warning

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AMD Ryzen 7 5800H with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
            [Host]   : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2 DEBUG
            .NET 7.0 : .NET 7.0.2 (7.0.222.60605), X64 RyuJIT AVX2
 
-Job = .NET 7.0  Runtime=.NET 7.0 
+Job = .NET 7.0  Runtime=.NET 7.0
 ```
 
 | Method  |    Mean | Ratio |       Gen0 |      Gen1 |    Allocated | Alloc Ratio |
@@ -26,6 +26,21 @@ Job = .NET 7.0  Runtime=.NET 7.0
 | Aws     | 2.173 s |  1.73 | 25000.0000 | 8000.0000 | 207 341.8 KB |      252.99 |
 | Minio   | 1.365 s |  1.08 |          - |         - | 279 989.3 KB |      341.64 |
 | Storage | 1.282 s |  1.00 |          - |         - |     819.5 KB |        1.00 |
+```ini
+BenchmarkDotNet=v0.13.5, OS=macOS Ventura 13.4 (22F66) [Darwin 22.5.0]
+Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
+.NET SDK=7.0.304
+  [Host]   : .NET 7.0.7 (7.0.723.27404), Arm64 RyuJIT AdvSIMD
+  .NET 7.0 : .NET 7.0.7 (7.0.723.27404), Arm64 RyuJIT AdvSIMD
+
+Job=.NET 7.0  Runtime=.NET 7.0
+```
+| Method  |    Mean |    Error |   StdDev | Ratio | RatioSD |       Gen0 |      Gen1 |    Allocated | Alloc Ratio |
+|---------|--------:|---------:|---------:|------:|--------:|-----------:|----------:|-------------:|------------:|
+| Aws     | 2.320 s | 0.0444 s | 0.0416 s |  1.01 |    0.02 | 33000.0000 | 8000.0000 | 203327.85 KB |      298.69 |
+| Minio   | 2.457 s | 0.0476 s | 0.0585 s |  1.08 |    0.03 |          - |         - | 279825.76 KB |      411.06 |
+| Storage | 2.292 s | 0.0351 s | 0.0329 s |  1.00 |    0.00 |          - |         - |    680.74 KB |        1.00 |
+
 
 ## Создание клиента
 
@@ -36,7 +51,7 @@ var storageClient = new S3Client(new S3Settings
 {
     AccessKey = "ROOTUSER",
     Bucket = "mybucket",
-    EndPoint = "localhost",     // для Yandex.Objects это "storage.yandexcloud.net" 
+    EndPoint = "localhost",     // для Yandex.Objects это "storage.yandexcloud.net"
     Port = 9000,                // стандартный порт Minio - 9000, для Yandex.Objects указывать не нужно
     SecretKey = "ChangeMe123",
     UseHttps = false,           // для Yandex.Objects укажите true
@@ -56,7 +71,7 @@ Amazon S3 не тестировался.
 
 ```csharp
 bool bucketCreateResult = await storageClient.CreateBucket(cancellationToken);
-Console.WriteLine(bucketCreateResult 
+Console.WriteLine(bucketCreateResult
     ? "Bucket создан"
     : $"Bucket не был создан");
 ```
@@ -106,7 +121,7 @@ if (!await upload.Upload(byteArray, cancellationToken)) { // загружаем 
     await upload.Abort(cancellationToken); // отменяем загрузку
 }
 else {
-    await upload.Complete(cancellationToken); // завершаем загрузку    
+    await upload.Complete(cancellationToken); // завершаем загрузку
 }
 
 ```

--- a/Stylecop.RuleSet
+++ b/Stylecop.RuleSet
@@ -1,0 +1,254 @@
+<?xml version="1.0"?>
+<RuleSet Name="StyleCop.Analyzers rules with default action"
+		 Description="StyleCop.Analyzers with default action. Rules with IsEnabledByDefault = false are disabled."
+		 ToolsVersion="14.0">
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.SpecialRules">
+		<Rule Id="SA0001" Action="None"/>          <!-- XML comment analysis disabled -->
+		<Rule Id="SA0002" Action="Warning"/>          <!-- Invalid settings file -->
+	</Rules>
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.SpacingRules">
+		<Rule Id="SA1000" Action="Warning"/>          <!-- Keywords should be spaced correctly -->
+		<Rule Id="SA1001" Action="Warning"/>          <!-- Commas should be spaced correctly -->
+		<Rule Id="SA1002" Action="Warning"/>          <!-- Semicolons should be spaced correctly -->
+		<Rule Id="SA1003" Action="Warning"/>          <!-- Symbols should be spaced correctly -->
+		<Rule Id="SA1004" Action="Warning"/>          <!-- Documentation lines should begin with single space -->
+		<Rule Id="SA1005" Action="Warning"/>          <!-- Single line comments should begin with single space -->
+		<Rule Id="SA1006" Action="Warning"/>          <!-- Preprocessor keywords should not be preceded by space -->
+		<Rule Id="SA1007" Action="Warning"/>          <!-- Operator keyword should be followed by space -->
+		<Rule Id="SA1008" Action="Warning"/>          <!-- Opening parenthesis should be spaced correctly -->
+		<Rule Id="SA1009" Action="Warning"/>          <!-- Closing parenthesis should be spaced correctly -->
+		<Rule Id="SA1010" Action="Warning"/>          <!-- Opening square brackets should be spaced correctly -->
+		<Rule Id="SA1011" Action="Warning"/>          <!-- Closing square brackets should be spaced correctly -->
+		<Rule Id="SA1012" Action="Warning"/>          <!-- Opening braces should be spaced correctly -->
+		<Rule Id="SA1013" Action="Warning"/>          <!-- Closing braces should be spaced correctly -->
+		<Rule Id="SA1014" Action="Warning"/>          <!-- Opening generic brackets should be spaced correctly -->
+		<Rule Id="SA1015" Action="Warning"/>          <!-- Closing generic brackets should be spaced correctly -->
+		<Rule Id="SA1016" Action="Warning"/>          <!-- Opening attribute brackets should be spaced correctly -->
+		<Rule Id="SA1017" Action="Warning"/>          <!-- Closing attribute brackets should be spaced correctly -->
+		<Rule Id="SA1018" Action="Warning"/>          <!-- Nullable type symbols should be spaced correctly -->
+		<Rule Id="SA1019" Action="Warning"/>          <!-- Member access symbols should be spaced correctly -->
+		<Rule Id="SA1020" Action="Warning"/>          <!-- Increment decrement symbols should be spaced correctly -->
+		<Rule Id="SA1021" Action="Warning"/>          <!-- Negative signs should be spaced correctly -->
+		<Rule Id="SA1022" Action="Warning"/>          <!-- Positive signs should be spaced correctly -->
+		<Rule Id="SA1023" Action="None"/>          <!-- Dereference and access of symbols should be spaced correctly -->
+		<Rule Id="SA1024" Action="Warning"/>          <!-- Colons should be spaced correctly -->
+		<Rule Id="SA1025" Action="Warning"/>          <!-- Code should not contain multiple whitespace in a row -->
+		<Rule Id="SA1026"
+			  Action="Warning"/>          <!-- Code should not contain space after new or stackalloc keyword in implicitly typed array allocation -->
+		<Rule Id="SA1027" Action="None"/>          <!-- Use tabs correctly -->
+		<Rule Id="SA1028" Action="Warning"/>          <!-- Code should not contain trailing whitespace -->
+	</Rules>
+
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.ReadabilityRules">
+		<Rule Id="SA1100"
+			  Action="Warning"/>          <!-- Do not prefix calls with base unless local implementation exists -->
+		<Rule Id="SA1101" Action="None"/>          <!-- Prefix local calls with this -->
+		<Rule Id="SX1101"
+			  Action="Error"/>          <!--  A call to an instance member of the local class or a base class is prefixed with this. -->
+		<Rule Id="SA1102" Action="Warning"/>          <!-- Query clause should follow previous clause -->
+		<Rule Id="SA1103"
+			  Action="Warning"/>          <!-- Query clauses should be on separate lines or all on one line -->
+		<Rule Id="SA1104"
+			  Action="Warning"/>          <!-- Query clause should begin on new line when previous clause spans multiple lines -->
+		<Rule Id="SA1105"
+			  Action="Warning"/>          <!-- Query clauses spanning multiple lines should begin on own line -->
+		<Rule Id="SA1106" Action="Error"/>          <!-- Code should not contain empty statements -->
+		<Rule Id="SA1107" Action="Error"/>          <!-- Code should not contain multiple statements on one line -->
+		<Rule Id="SA1108" Action="Error"/>          <!-- Block statements should not contain embedded comments -->
+		<Rule Id="SA1109" Action="Error"/>             <!-- Block statements should not contain embedded regions -->
+		<Rule Id="SA1110"
+			  Action="Error"/>          <!-- Opening parenthesis or bracket should be on declaration line -->
+		<Rule Id="SA1111" Action="Error"/>          <!-- Closing parenthesis should be on line of last parameter -->
+		<Rule Id="SA1112"
+			  Action="Error"/>          <!-- Closing parenthesis should be on line of opening parenthesis -->
+		<Rule Id="SA1113" Action="Error"/>          <!-- Comma should be on the same line as previous parameter -->
+		<Rule Id="SA1114" Action="Error"/>          <!-- Parameter list should follow declaration -->
+		<Rule Id="SA1115" Action="Error"/>          <!-- Parameter should follow comma -->
+		<Rule Id="SA1116" Action="Error"/>          <!-- Split parameters should start on line after declaration -->
+		<Rule Id="SA1117" Action="Error"/>          <!-- Parameters should be on same line or separate lines -->
+		<Rule Id="SA1118" Action="Warning"/>          <!-- [TO ERROR] Parameter should not span multiple lines -->
+		<Rule Id="SA1120" Action="Error"/>          <!-- Comments should contain text -->
+		<Rule Id="SA1121" Action="Error"/>          <!-- Use built-in type alias -->
+		<Rule Id="SA1122" Action="Error"/>          <!-- Use string.Empty for empty strings -->
+		<Rule Id="SA1123" Action="Error"/>          <!-- Do not place regions within elements -->
+		<Rule Id="SA1124" Action="Error"/>          <!-- Do not use regions -->
+		<Rule Id="SA1125" Action="Error"/>          <!-- Use shorthand for nullable types -->
+		<Rule Id="SA1126" Action="None"/>             <!-- Prefix calls correctly -->
+		<Rule Id="SA1127" Action="Error"/>          <!-- Generic type constraints should be on their own line -->
+		<Rule Id="SA1128" Action="None"/>          <!-- Put constructor initializers on their own line -->
+		<Rule Id="SA1129" Action="Info"/>          <!-- Do not use default value type constructor -->
+		<Rule Id="SA1130" Action="Warning"/>          <!-- Use lambda syntax -->
+		<Rule Id="SA1131" Action="Warning"/>          <!-- Use readable conditions -->
+		<Rule Id="SA1132" Action="Error"/>          <!-- Do not combine fields -->
+		<Rule Id="SA1133" Action="Error"/>          <!-- Do not combine attributes -->
+		<Rule Id="SA1134" Action="Error"/>          <!-- Attributes should not share line -->
+		<Rule Id="SA1135" Action="None"/>          <!-- Using directives should be qualified -->
+		<Rule Id="SA1136" Action="Error"/>          <!-- Enum values should be on separate lines -->
+		<Rule Id="SA1137" Action="Warning"/>          <!-- Elements should have the same indentation -->
+		<Rule Id="SA1139" Action="Warning"/>          <!-- Use literal suffix notation instead of casting -->
+		<Rule Id="SA1141"
+			  Action="Warning"/>          <!-- A ValueTuple type declaration was used instead of the preferred tuple language construct. -->
+		<Rule Id="SA1142"
+			  Action="Warning"/>          <!-- An element of a tuple was referenced by its metadata name when an element name is available. -->
+	</Rules>
+
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.OrderingRules">
+		<Rule Id="SA1200" Action="None"/>          <!-- Using directives should be placed correctly -->
+		<Rule Id="SA1201" Action="Error"/>          <!-- Elements should appear in the correct order -->
+		<Rule Id="SA1202" Action="Error"/>          <!-- Elements should be ordered by access -->
+		<Rule Id="SA1203" Action="Error"/>          <!-- Constants should appear before fields -->
+		<Rule Id="SA1204" Action="Error"/>          <!-- Static elements should appear before instance elements -->
+		<Rule Id="SA1205" Action="Error"/>          <!-- Partial elements should declare access -->
+		<Rule Id="SA1206" Action="Error"/>          <!-- Declaration keywords should follow order -->
+		<Rule Id="SA1207" Action="Error"/>          <!-- Protected should come before internal -->
+		<Rule Id="SA1208"
+			  Action="Error"/>          <!-- System using directives should be placed before other using directives -->
+		<Rule Id="SA1209"
+			  Action="Error"/>          <!-- Using alias directives should be placed after other using directives -->
+		<Rule Id="SA1210"
+			  Action="Error"/>          <!-- Using directives should be ordered alphabetically by namespace -->
+		<Rule Id="SA1211"
+			  Action="Error"/>          <!-- Using alias directives should be ordered alphabetically by alias name -->
+		<Rule Id="SA1212" Action="Error"/>          <!-- Property accessors should follow order -->
+		<Rule Id="SA1213" Action="None"/>          <!-- Event accessors should follow order -->
+		<Rule Id="SA1214" Action="Error"/>          <!-- Readonly fields should appear before non-readonly fields -->
+		<Rule Id="SA1216"
+			  Action="Error"/>          <!-- Using static directives should be placed at the correct location -->
+		<Rule Id="SA1217" Action="Warning"/>          <!-- Using static directives should be ordered alphabetically -->
+	</Rules>
+
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.NamingRules">
+		<Rule Id="SA1300" Action="Error"/>          <!-- Element should begin with upper-case letter -->
+		<Rule Id="SA1301" Action="None"/>             <!-- Element should begin with lower-case letter -->
+		<Rule Id="SA1302" Action="Error"/>          <!-- Interface names should begin with I -->
+		<Rule Id="SA1303" Action="Error"/>          <!-- Const field names should begin with upper-case letter -->
+		<Rule Id="SA1304"
+			  Action="Error"/>          <!-- Non-private readonly fields should begin with upper-case letter -->
+		<Rule Id="SA1305"
+			  Action="Warning"/>             <!-- [TO ERROR] Field names should not use Hungarian notation -->
+		<Rule Id="SA1306" Action="None"/>          <!-- Field names should begin with lower-case letter -->
+		<Rule Id="SA1307" Action="Error"/>          <!-- Accessible fields should begin with upper-case letter -->
+		<Rule Id="SA1308" Action="Error"/>          <!-- Variable names should not be prefixed -->
+		<Rule Id="SA1309" Action="None"/>          <!-- Field names should not begin with underscore -->
+		<Rule Id="SA1310" Action="None"/>          <!-- Field names should not contain underscore -->
+		<Rule Id="SA1311" Action="Error"/>          <!-- Static readonly fields should begin with upper-case letter -->
+		<Rule Id="SA1312" Action="Error"/>          <!-- Variable names should begin with lower-case letter -->
+		<Rule Id="SA1313" Action="Error"/>          <!-- Parameter names should begin with lower-case letter -->
+		<Rule Id="SA1314" Action="Error"/>          <!-- Type parameter names should begin with T -->
+		<Rule Id="SA1316"
+			  Action="Error"/>          <!-- Element names within a tuple type should have the correct casing.-->
+		<Rule Id="SX1309" Action="Error"/>             <!-- Field names should begin with underscore -->
+		<Rule Id="SX1309S" Action="None"/>             <!-- Static field names should begin with underscore -->
+	</Rules>
+
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.MaintainabilityRules">
+		<Rule Id="SA1119" Action="Info"/>          <!-- Statement should not use unnecessary parenthesis -->
+		<Rule Id="SA1400" Action="Warning"/>          <!-- Access modifier should be declared -->
+		<Rule Id="SA1401" Action="Error"/>          <!-- Fields should be private -->
+		<Rule Id="SA1402" Action="Warning"/>          <!-- File may only contain a single type -->
+		<Rule Id="SA1403" Action="Error"/>          <!-- File may only contain a single namespace -->
+		<Rule Id="SA1404" Action="Warning"/>          <!-- Code analysis suppression should have justification -->
+		<Rule Id="SA1405" Action="Warning"/>          <!-- Debug.Assert should provide message text -->
+		<Rule Id="SA1406" Action="Warning"/>          <!-- Debug.Fail should provide message text -->
+		<Rule Id="SA1407" Action="Warning"/>          <!-- Arithmetic expressions should declare precedence -->
+		<Rule Id="SA1408" Action="Warning"/>          <!-- Conditional expressions should declare precedence -->
+		<Rule Id="SA1409" Action="Warning"/>          <!-- Remove unnecessary code -->
+		<Rule Id="SA1410" Action="Warning"/>          <!-- Remove delegate parenthesis when possible -->
+		<Rule Id="SA1411" Action="None"/>          <!-- Attribute constructor should not use unnecessary parenthesis -->
+		<Rule Id="SA1412" Action="None"/>          <!-- Store files as UTF-8 with byte order mark -->
+		<Rule Id="SA1413" Action="Warning"/>          <!-- Use trailing comma in multi-line initializers -->
+		<Rule Id="SA1414"
+			  Action="Warning"/>          <!-- A tuple type without element names is present in a member declaration. -->
+	</Rules>
+
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.LayoutRules">
+		<Rule Id="SA1500" Action="Warning"/>          <!-- Braces for multi-line statements should not share line -->
+		<Rule Id="SA1501" Action="Warning"/>          <!-- Statement should not be on a single line -->
+		<Rule Id="SA1502" Action="Warning"/>          <!-- Element should not be on a single line -->
+		<Rule Id="SA1503" Action="Warning"/>          <!-- Braces should not be omitted -->
+		<Rule Id="SA1504" Action="Warning"/>          <!-- All accessors should be single-line or multi-line -->
+		<Rule Id="SA1505" Action="Warning"/>          <!-- Opening braces should not be followed by blank line -->
+		<Rule Id="SA1506"
+			  Action="Warning"/>          <!-- Element documentation headers should not be followed by blank line -->
+		<Rule Id="SA1507" Action="Warning"/>          <!-- Code should not contain multiple blank lines in a row -->
+		<Rule Id="SA1508" Action="Warning"/>          <!-- Closing braces should not be preceded by blank line -->
+		<Rule Id="SA1509" Action="Warning"/>          <!-- Opening braces should not be preceded by blank line -->
+		<Rule Id="SA1510"
+			  Action="Warning"/>          <!-- Chained statement blocks should not be preceded by blank line -->
+		<Rule Id="SA1511" Action="Warning"/>          <!-- While-do footer should not be preceded by blank line -->
+		<Rule Id="SA1512" Action="Warning"/>          <!-- Single-line comments should not be followed by blank line -->
+		<Rule Id="SA1513" Action="Warning"/>          <!-- Closing brace should be followed by blank line -->
+		<Rule Id="SA1514"
+			  Action="Warning"/>          <!-- Element documentation header should be preceded by blank line -->
+		<Rule Id="SA1515" Action="Warning"/>          <!-- Single-line comment should be preceded by blank line -->
+		<Rule Id="SA1516" Action="Warning"/>          <!-- Elements should be separated by blank line -->
+		<Rule Id="SA1517" Action="Warning"/>          <!-- Code should not contain blank lines at start of file -->
+		<Rule Id="SA1518" Action="None"/>          <!-- Use line endings correctly at end of file -->
+		<Rule Id="SA1519"
+			  Action="Warning"/>          <!-- Braces should not be omitted from multi-line child statement -->
+		<Rule Id="SA1520" Action="Warning"/>          <!-- Use braces consistently -->
+	</Rules>
+
+	<Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.DocumentationRules">
+		<Rule Id="SA1600" Action="None"/>          <!-- Elements should be documented -->
+		<Rule Id="SA1601" Action="None"/>          <!-- Partial elements should be documented -->
+		<Rule Id="SA1602" Action="None"/>          <!-- Enumeration items should be documented -->
+		<Rule Id="SA1603" Action="None"/>             <!-- Documentation should contain valid XML -->
+		<Rule Id="SA1604" Action="None"/>          <!-- Element documentation should have summary -->
+		<Rule Id="SA1605" Action="None"/>          <!-- Partial element documentation should have summary -->
+		<Rule Id="SA1606" Action="None"/>          <!-- Element documentation should have summary text -->
+		<Rule Id="SA1607" Action="None"/>          <!-- Partial element documentation should have summary text -->
+		<Rule Id="SA1608" Action="None"/>          <!-- Element documentation should not have default summary -->
+		<Rule Id="SA1609" Action="None"/>             <!-- Property documentation should have value -->
+		<Rule Id="SA1610" Action="None"/>          <!-- Property documentation should have value text -->
+		<Rule Id="SA1611" Action="None"/>          <!-- Element parameters should be documented -->
+		<Rule Id="SA1612"
+			  Action="None"/>          <!-- Element parameter documentation should match element parameters -->
+		<Rule Id="SA1613"
+			  Action="None"/>          <!-- Element parameter documentation should declare parameter name -->
+		<Rule Id="SA1614" Action="None"/>          <!-- Element parameter documentation should have text -->
+		<Rule Id="SA1615" Action="None"/>          <!-- Element return value should be documented -->
+		<Rule Id="SA1616" Action="None"/>          <!-- Element return value documentation should have text -->
+		<Rule Id="SA1617" Action="None"/>          <!-- Void return value should not be documented -->
+		<Rule Id="SA1618" Action="None"/>          <!-- Generic type parameters should be documented -->
+		<Rule Id="SA1619" Action="None"/>          <!-- Generic type parameters should be documented partial class -->
+		<Rule Id="SA1620"
+			  Action="None"/>          <!-- Generic type parameter documentation should match type parameters -->
+		<Rule Id="SA1621"
+			  Action="None"/>          <!-- Generic type parameter documentation should declare parameter name -->
+		<Rule Id="SA1622" Action="None"/>          <!-- Generic type parameter documentation should have text -->
+		<Rule Id="SA1623" Action="None"/>          <!-- Property summary documentation should match accessors -->
+		<Rule Id="SA1624"
+			  Action="None"/>          <!-- Property summary documentation should omit accessor with restricted access -->
+		<Rule Id="SA1625" Action="None"/>          <!-- Element documentation should not be copied and pasted -->
+		<Rule Id="SA1626"
+			  Action="None"/>          <!-- Single-line comments should not use documentation style slashes -->
+		<Rule Id="SA1627" Action="None"/>          <!-- Documentation text should not be empty -->
+		<Rule Id="SA1628" Action="None"/>             <!-- Documentation text should begin with a capital letter -->
+		<Rule Id="SA1629" Action="None"/>          <!-- Documentation text should end with a period -->
+		<Rule Id="SA1630" Action="None"/>             <!-- Documentation text should contain whitespace -->
+		<Rule Id="SA1631" Action="None"/>             <!-- Documentation should meet character percentage -->
+		<Rule Id="SA1632" Action="None"/>             <!-- Documentation text should meet minimum character length -->
+		<Rule Id="SA1633" Action="None"/>          <!-- File should have header -->
+		<Rule Id="SA1634" Action="None"/>          <!-- File header should show copyright -->
+		<Rule Id="SA1635" Action="None"/>          <!-- File header should have copyright text -->
+		<Rule Id="SA1636" Action="None"/>          <!-- File header copyright text should match -->
+		<Rule Id="SA1637" Action="None"/>          <!-- File header should contain file name -->
+		<Rule Id="SA1638" Action="None"/>          <!-- File header file name documentation should match file name -->
+		<Rule Id="SA1639" Action="None"/>          <!-- File header should have summary -->
+		<Rule Id="SA1640" Action="None"/>          <!-- File header should have valid company text -->
+		<Rule Id="SA1641" Action="None"/>          <!-- File header company name text should match -->
+		<Rule Id="SA1642"
+			  Action="None"/>          <!-- Constructor summary documentation should begin with standard text -->
+		<Rule Id="SA1643"
+			  Action="None"/>          <!-- Destructor summary documentation should begin with standard text -->
+		<Rule Id="SA1644" Action="None"/>             <!-- Documentation headers should not contain blank lines -->
+		<Rule Id="SA1645" Action="None"/>             <!-- Included documentation file does not exist -->
+		<Rule Id="SA1646" Action="None"/>             <!-- Included documentation XPath does not exist -->
+		<Rule Id="SA1647" Action="None"/>             <!-- Include node does not contain valid file and path -->
+		<Rule Id="SA1648" Action="None"/>          <!-- Inheritdoc should be used with inheriting class -->
+		<Rule Id="SA1649" Action="None"/>          <!-- File name should match first type name -->
+		<Rule Id="SA1650" Action="None"/>             <!-- Element documentation should be spelled correctly -->
+		<Rule Id="SA1651" Action="None"/>          <!-- Do not use placeholder elements -->
+	</Rules>
+</RuleSet>

--- a/src/Storage.Benchmark/InternalBenchmarks/DownloadBenchmark.cs
+++ b/src/Storage.Benchmark/InternalBenchmarks/DownloadBenchmark.cs
@@ -3,46 +3,43 @@ using Storage.Benchmark.Utils;
 
 namespace Storage.Benchmark.InternalBenchmarks;
 
-[MeanColumn, MemoryDiagnoser]
+[MeanColumn]
+[MemoryDiagnoser]
 [InProcess]
 public class DownloadBenchmark
 {
-    [Benchmark]
-    public async Task<int> JustDownload()
-    {
-        using var file = await _s3Client.GetFile(_fileId, _cancellation);
+	private CancellationToken _cancellation;
+	private string _fileId = null!;
+	private S3Client _s3Client = null!;
 
-        return await BenchmarkHelper.ReadStreamMock(
-            await file.GetStream(_cancellation),
-            BenchmarkHelper.StreamBuffer,
-            _cancellation);
-    }
+	[GlobalSetup]
+	public void Config()
+	{
+		var config = BenchmarkHelper.ReadConfiguration();
+		var settings = BenchmarkHelper.ReadSettings(config);
 
-    #region Configuration
+		_cancellation = new CancellationToken();
+		_fileId = "привет-как-делаdcd156a8-b6bd-4130-a2c7-8a38dbfebbc7";
+		_s3Client = BenchmarkHelper.CreateStoragesClient(settings);
 
-    private CancellationToken _cancellation;
-    private string _fileId = null!;
-    private S3Client _s3Client = null!;
+		// BenchmarkHelper.EnsureBucketExists(_storageClient, _cancellation);
+		// BenchmarkHelper.EnsureFileExists(config, _storageClient, _fileId, _cancellation);
+	}
 
-    [GlobalSetup]
-    public void Config()
-    {
-        var config = BenchmarkHelper.ReadConfiguration();
-        var settings = BenchmarkHelper.ReadSettings(config);
+	[GlobalCleanup]
+	public void Clear()
+	{
+		_s3Client.Dispose();
+	}
 
-        _cancellation = new CancellationToken();
-        _fileId = $"привет-как-делаdcd156a8-b6bd-4130-a2c7-8a38dbfebbc7";
-        _s3Client = BenchmarkHelper.CreateStoragesClient(settings);
+	[Benchmark]
+	public async Task<int> JustDownload()
+	{
+		using var file = await _s3Client.GetFile(_fileId, _cancellation);
 
-        // BenchmarkHelper.EnsureBucketExists(_storageClient, _cancellation);
-        // BenchmarkHelper.EnsureFileExists(config, _storageClient, _fileId, _cancellation);
-    }
-
-    [GlobalCleanup]
-    public void Clear()
-    {
-        _s3Client.Dispose();
-    }
-
-    #endregion
+		return await BenchmarkHelper.ReadStreamMock(
+			await file.GetStream(_cancellation),
+			BenchmarkHelper.StreamBuffer,
+			_cancellation);
+	}
 }

--- a/src/Storage.Benchmark/InternalBenchmarks/HashBenchmark.cs
+++ b/src/Storage.Benchmark/InternalBenchmarks/HashBenchmark.cs
@@ -6,38 +6,35 @@ using Storage.Utils;
 namespace Storage.Benchmark.InternalBenchmarks;
 
 [SimpleJob(RuntimeMoniker.Net70)]
-[MeanColumn, MemoryDiagnoser]
+[MeanColumn]
+[MemoryDiagnoser]
 public class HashBenchmark
 {
-    [Benchmark]
-    public int ByteHash()
-    {
-        return HashHelper
-            .GetPayloadHash(_byteData)
-            .Length;
-    }
+	private byte[] _byteData = null!;
+	private string _stringData = null!;
 
-    [Benchmark]
-    public int StringHash()
-    {
-        return HashHelper
-            .GetPayloadHash(_stringData)
-            .Length;
-    }
+	[GlobalSetup]
+	public void Config()
+	{
+		var config = BenchmarkHelper.ReadConfiguration();
 
-    #region Configuration
+		_byteData = BenchmarkHelper.ReadBigArray(config);
+		_stringData = "C10F4FFD-BB46-452C-B054-C595EB92248E";
+	}
 
-    private byte[] _byteData = null!;
-    private string _stringData = null!;
+	[Benchmark]
+	public int ByteHash()
+	{
+		return HashHelper
+			.GetPayloadHash(_byteData)
+			.Length;
+	}
 
-    [GlobalSetup]
-    public void Config()
-    {
-        var config = BenchmarkHelper.ReadConfiguration();
-
-        _byteData = BenchmarkHelper.ReadBigArray(config);
-        _stringData = "C10F4FFD-BB46-452C-B054-C595EB92248E";
-    }
-
-    #endregion
+	[Benchmark]
+	public int StringHash()
+	{
+		return HashHelper
+			.GetPayloadHash(_stringData)
+			.Length;
+	}
 }

--- a/src/Storage.Benchmark/InternalBenchmarks/SignatureBenchmark.cs
+++ b/src/Storage.Benchmark/InternalBenchmarks/SignatureBenchmark.cs
@@ -6,40 +6,43 @@ using Storage.Utils;
 namespace Storage.Benchmark.InternalBenchmarks;
 
 [SimpleJob(RuntimeMoniker.Net70)]
-[MeanColumn, MemoryDiagnoser]
+[MeanColumn]
+[MemoryDiagnoser]
 public class SignatureBenchmark
 {
-    [Benchmark]
-    public int Content() => _signature
-        .Calculate(_request, _payloadHash, _headers, _now)
-        .Length;
+	private string[] _headers = null!;
+	private DateTime _now;
+	private HttpRequestMessage _request = null!;
+	private string _payloadHash = null!;
+	private Signature _signature = null!;
 
-    [Benchmark]
-    public int Url() => _signature
-        .Calculate("http://subdomain-name.company-name.com/controller/method?arg=eto-arg", _now)
-        .Length;
+	[GlobalSetup]
+	public void Config()
+	{
+		var config = BenchmarkHelper.ReadConfiguration();
+		var data = BenchmarkHelper.ReadBigArray(config);
+		var settings = BenchmarkHelper.ReadSettings(config);
 
-    #region Configuration
+		_headers = new[] { "host", "x-amz-content-sha256", "x-amz-date" };
+		_now = DateTime.UtcNow;
+		_request = new HttpRequestMessage(HttpMethod.Post, "http://company-name.com/controller");
+		_payloadHash = HashHelper.GetPayloadHash(data);
+		_signature = new Signature(settings.SecretKey, settings.Region, settings.Service);
+	}
 
-    private string[] _headers = null!;
-    private DateTime _now;
-    private HttpRequestMessage _request = null!;
-    private string _payloadHash = null!;
-    private Signature _signature = null!;
+	[Benchmark]
+	public int Content()
+	{
+		return _signature
+			.Calculate(_request, _payloadHash, _headers, _now)
+			.Length;
+	}
 
-    [GlobalSetup]
-    public void Config()
-    {
-        var config = BenchmarkHelper.ReadConfiguration();
-        var data = BenchmarkHelper.ReadBigArray(config);
-        var settings = BenchmarkHelper.ReadSettings(config);
-
-        _headers = new[] {"host", "x-amz-content-sha256", "x-amz-date"};
-        _now = DateTime.UtcNow;
-        _request = new HttpRequestMessage(HttpMethod.Post, "http://company-name.com/controller");
-        _payloadHash = HashHelper.GetPayloadHash(data);
-        _signature = new Signature(settings.SecretKey, settings.Region, settings.Service);
-    }
-
-    #endregion
+	[Benchmark]
+	public int Url()
+	{
+		return _signature
+			.Calculate("http://subdomain-name.company-name.com/controller/method?arg=eto-arg", _now)
+			.Length;
+	}
 }

--- a/src/Storage.Benchmark/Program.cs
+++ b/src/Storage.Benchmark/Program.cs
@@ -1,11 +1,4 @@
 ﻿using BenchmarkDotNet.Running;
+using Storage.Benchmark;
 
-namespace Storage.Benchmark;
-
-public static class Program
-{
-    public static void Main(string[] args)
-    {
-        BenchmarkRunner.Run<S3Benchmark>();
-    }
-}
+BenchmarkRunner.Run<S3Benchmark>();

--- a/src/Storage.Benchmark/S3Benchmark.cs
+++ b/src/Storage.Benchmark/S3Benchmark.cs
@@ -1,6 +1,7 @@
 ﻿using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;
+using Amazon.S3.Util;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Minio;
@@ -9,182 +10,207 @@ using Storage.Benchmark.Utils;
 namespace Storage.Benchmark;
 
 [SimpleJob(RuntimeMoniker.Net70)]
-[MeanColumn, MemoryDiagnoser]
+[MeanColumn]
+[MemoryDiagnoser]
 public class S3Benchmark
 {
-    [Benchmark]
-    public async Task<int> Aws()
-    {
-        var result = 0;
-    
-        await Amazon.S3.Util.AmazonS3Util.DoesS3BucketExistV2Async(_amazonClient, _bucket);
-    
-        try
-        {
-            await _amazonClient.GetObjectMetadataAsync(_bucket, _fileId, _cancellation);
-        }
-        catch (Exception)
-        {
-            result++; // it's OK - file not found
-        }
-    
-        _inputData.Seek(0, SeekOrigin.Begin);
-    
-        await _amazonTransfer.UploadAsync(_inputData, _bucket, _fileId, _cancellation);
-        result++;
-    
-        await _amazonClient.GetObjectMetadataAsync(_bucket, _fileId, _cancellation);
-        result++;
-    
-        _outputData.Seek(0, SeekOrigin.Begin);
-        var fileDownload = await _amazonClient.GetObjectAsync(_bucket, _fileId, _cancellation);
-        await fileDownload.ResponseStream.CopyToAsync(_outputData, _cancellation);
-        result++;
-    
-        await _amazonClient.DeleteObjectAsync(new DeleteObjectRequest
-        {
-            BucketName = _bucket,
-            Key = _fileId
-        }, _cancellation);
-    
-        return ++result;
-    }
-    
-    [Benchmark]
-    public async Task<int> Minio()
-    {
-        var result = 0;
-    
-        if (!await _minioClient.BucketExistsAsync(new BucketExistsArgs().WithBucket(_bucket), _cancellation))
-        {
-            ThrowException();
-        }
-    
-        result++;
-    
-        try
-        {
-            await _minioClient.StatObjectAsync(new StatObjectArgs()
-                .WithBucket(_bucket)
-                .WithObject(_fileId), _cancellation);
-        }
-        catch (Exception)
-        {
-            result++; // it's OK - file not found
-        }
-    
-        _inputData.Seek(0, SeekOrigin.Begin);
-        await _minioClient.PutObjectAsync(new PutObjectArgs()
-            .WithBucket(_bucket)
-            .WithObject(_fileId)
-            .WithObjectSize(_inputData.Length)
-            .WithStreamData(_inputData)
-            .WithContentType("application/pdf"), _cancellation);
-    
-        result++;
-    
-        await _minioClient.StatObjectAsync(new StatObjectArgs()
-            .WithBucket(_bucket)
-            .WithObject(_fileId), _cancellation);
-    
-        result++;
-    
-        _outputData.Seek(0, SeekOrigin.Begin);
-        await _minioClient.GetObjectAsync(new GetObjectArgs()
-                .WithBucket(_bucket)
-                .WithObject(_fileId)
-                .WithCallbackStream((file, ct) => file.CopyToAsync(_outputData, ct)),
-            _cancellation);
-    
-        result++;
-    
-        await _minioClient.RemoveObjectAsync(new RemoveObjectArgs()
-            .WithBucket(_bucket)
-            .WithObject(_fileId), _cancellation);
-    
-        return ++result;
-    }
+	private string _bucket = null!;
+	private CancellationToken _cancellation;
+	private InputStream _inputData = null!;
+	private string _fileId = null!;
+	private MemoryStream _outputData = null!;
 
-    [Benchmark(Baseline = true)]
-    public async Task<int> Storage()
-    {
-        var result = 0;
+	private IAmazonS3 _amazonClient = null!;
+	private TransferUtility _amazonTransfer = null!;
+	private MinioClient _minioClient = null!;
+	private S3Client _s3Client = null!;
 
-        var bucketExistsResult = await _s3Client.IsBucketExists(_cancellation);
-        if (!bucketExistsResult) ThrowException();
-        result++;
+	[GlobalSetup]
+	public void Config()
+	{
+		var config = BenchmarkHelper.ReadConfiguration();
+		var settings = BenchmarkHelper.ReadSettings(config);
 
-        var fileExistsResult = await _s3Client.IsFileExists(_fileId, _cancellation);
-        if (fileExistsResult) ThrowException();
-        result++;
+		_bucket = settings.Bucket;
+		_cancellation = default;
+		_fileId = $"привет-как-дела{Guid.NewGuid()}";
+		_inputData = BenchmarkHelper.ReadBigFile(config);
+		_outputData = new MemoryStream(new byte[_inputData.Length]);
 
-        _inputData.Seek(0, SeekOrigin.Begin);
-        var fileUploadResult = await _s3Client.UploadFile(_fileId, "application/pdf", _inputData, _cancellation);
-        if (!fileUploadResult) ThrowException();
+		_amazonClient = BenchmarkHelper.CreateAWSClient(settings);
+		_amazonTransfer = new TransferUtility(_amazonClient);
+		_minioClient = BenchmarkHelper.CreateMinioClient(settings);
+		_s3Client = BenchmarkHelper.CreateStoragesClient(settings);
 
-        result++;
+		BenchmarkHelper.EnsureBucketExists(_s3Client, _cancellation);
+	}
 
-        fileExistsResult = await _s3Client.IsFileExists(_fileId, _cancellation);
-        if (!fileExistsResult) ThrowException();
-        result++;
+	[GlobalCleanup]
+	public void Clear()
+	{
+		_s3Client.Dispose();
+		_inputData.Dispose();
+		_outputData.Dispose();
+	}
 
-        _outputData.Seek(0, SeekOrigin.Begin);
-        var storageFile = await _s3Client.GetFile(_fileId, _cancellation);
-        if (!storageFile) ThrowException(storageFile.ToString());
+	[Benchmark]
+	public async Task<int> Aws()
+	{
+		var result = 0;
 
-        var fileStream = await storageFile.GetStream(_cancellation);
-        await fileStream.CopyToAsync(_outputData, _cancellation);
+		await AmazonS3Util.DoesS3BucketExistV2Async(_amazonClient, _bucket);
 
-        storageFile.Dispose();
+		try
+		{
+			await _amazonClient.GetObjectMetadataAsync(_bucket, _fileId, _cancellation);
+		}
+		catch (Exception)
+		{
+			result++; // it's OK - file not found
+		}
 
-        result++;
+		_inputData.Seek(0, SeekOrigin.Begin);
 
-        await _s3Client.DeleteFile(_fileId, _cancellation);
-        return ++result;
-    }
+		await _amazonTransfer.UploadAsync(_inputData, _bucket, _fileId, _cancellation);
+		result++;
 
-    #region Configuration
+		await _amazonClient.GetObjectMetadataAsync(_bucket, _fileId, _cancellation);
+		result++;
 
-    private string _bucket = null!;
-    private CancellationToken _cancellation;
-    private InputStream _inputData = null!;
-    private string _fileId = null!;
-    private MemoryStream _outputData = null!;
+		_outputData.Seek(0, SeekOrigin.Begin);
+		var fileDownload = await _amazonClient.GetObjectAsync(_bucket, _fileId, _cancellation);
+		await fileDownload.ResponseStream.CopyToAsync(_outputData, _cancellation);
+		result++;
 
-    private IAmazonS3 _amazonClient = null!;
-    private TransferUtility _amazonTransfer = null!;
-    private MinioClient _minioClient = null!;
-    private S3Client _s3Client = null!;
+		await _amazonClient.DeleteObjectAsync(
+			new DeleteObjectRequest { BucketName = _bucket, Key = _fileId },
+			_cancellation);
 
-    [GlobalSetup]
-    public void Config()
-    {
-        var config = BenchmarkHelper.ReadConfiguration();
-        var settings = BenchmarkHelper.ReadSettings(config);
+		return ++result;
+	}
 
-        _bucket = settings.Bucket;
-        _cancellation = new CancellationToken();
-        _fileId = $"привет-как-дела{Guid.NewGuid()}";
-        _inputData = BenchmarkHelper.ReadBigFile(config);
-        _outputData = new MemoryStream(new byte[_inputData.Length]);
+	[Benchmark]
+	public async Task<int> Minio()
+	{
+		var result = 0;
 
-        _amazonClient = BenchmarkHelper.CreateAWSClient(settings);
-        _amazonTransfer = new TransferUtility(_amazonClient);
-        _minioClient = BenchmarkHelper.CreateMinioClient(settings);
-        _s3Client = BenchmarkHelper.CreateStoragesClient(settings);
+		if (!await _minioClient.BucketExistsAsync(new BucketExistsArgs().WithBucket(_bucket), _cancellation))
+		{
+			ThrowException();
+		}
 
-        BenchmarkHelper.EnsureBucketExists(_s3Client, _cancellation);
-    }
+		result++;
 
-    [GlobalCleanup]
-    public void Clear()
-    {
-        _s3Client.Dispose();
-        _inputData.Dispose();
-        _outputData.Dispose();
-    }
+		try
+		{
+			await _minioClient.StatObjectAsync(
+				new StatObjectArgs()
+				.WithBucket(_bucket)
+				.WithObject(_fileId),
+				_cancellation);
+		}
+		catch (Exception)
+		{
+			result++; // it's OK - file not found
+		}
 
-    private static void ThrowException(string? message = null) => throw new Exception(message);
+		_inputData.Seek(0, SeekOrigin.Begin);
+		await _minioClient.PutObjectAsync(
+			new PutObjectArgs()
+				.WithBucket(_bucket)
+				.WithObject(_fileId)
+				.WithObjectSize(_inputData.Length)
+				.WithStreamData(_inputData)
+				.WithContentType("application/pdf"),
+			_cancellation);
 
-    #endregion
+		result++;
+
+		await _minioClient.StatObjectAsync(
+			new StatObjectArgs()
+				.WithBucket(_bucket)
+				.WithObject(_fileId),
+			_cancellation);
+
+		result++;
+
+		_outputData.Seek(0, SeekOrigin.Begin);
+		await _minioClient.GetObjectAsync(
+			new GetObjectArgs()
+				.WithBucket(_bucket)
+				.WithObject(_fileId)
+				.WithCallbackStream((file, ct) => file.CopyToAsync(_outputData, ct)),
+			_cancellation);
+
+		result++;
+
+		await _minioClient.RemoveObjectAsync(
+			new RemoveObjectArgs()
+				.WithBucket(_bucket)
+				.WithObject(_fileId),
+			_cancellation);
+
+		return ++result;
+	}
+
+	[Benchmark(Baseline = true)]
+	public async Task<int> Storage()
+	{
+		var result = 0;
+
+		var bucketExistsResult = await _s3Client.IsBucketExists(_cancellation);
+		if (!bucketExistsResult)
+		{
+			ThrowException();
+		}
+
+		result++;
+
+		var fileExistsResult = await _s3Client.IsFileExists(_fileId, _cancellation);
+		if (fileExistsResult)
+		{
+			ThrowException();
+		}
+
+		result++;
+
+		_inputData.Seek(0, SeekOrigin.Begin);
+		var fileUploadResult = await _s3Client.UploadFile(_fileId, "application/pdf", _inputData, _cancellation);
+		if (!fileUploadResult)
+		{
+			ThrowException();
+		}
+
+		result++;
+
+		fileExistsResult = await _s3Client.IsFileExists(_fileId, _cancellation);
+		if (!fileExistsResult)
+		{
+			ThrowException();
+		}
+
+		result++;
+
+		_outputData.Seek(0, SeekOrigin.Begin);
+		var storageFile = await _s3Client.GetFile(_fileId, _cancellation);
+		if (!storageFile)
+		{
+			ThrowException(storageFile.ToString());
+		}
+
+		var fileStream = await storageFile.GetStream(_cancellation);
+		await fileStream.CopyToAsync(_outputData, _cancellation);
+
+		storageFile.Dispose();
+
+		result++;
+
+		await _s3Client.DeleteFile(_fileId, _cancellation);
+		return ++result;
+	}
+
+	private static void ThrowException(string? message = null)
+	{
+		throw new Exception(message);
+	}
 }

--- a/src/Storage.Benchmark/Storage.Benchmark.csproj
+++ b/src/Storage.Benchmark/Storage.Benchmark.csproj
@@ -11,6 +11,10 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Storage.Benchmark/Utils/BenchmarkHelper.cs
+++ b/src/Storage.Benchmark/Utils/BenchmarkHelper.cs
@@ -8,129 +8,149 @@ namespace Storage.Benchmark.Utils;
 
 internal static class BenchmarkHelper
 {
-    public static readonly byte[] StreamBuffer = new byte[2048];
+	public static readonly byte[] StreamBuffer = new byte[2048];
 
-    // ReSharper disable once InconsistentNaming
-    public static AmazonS3Client CreateAWSClient(S3Settings settings)
-    {
-        var scheme = settings.UseHttps ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
-        var port = settings.Port.HasValue ? $":{settings.Port}" : string.Empty;
+	// ReSharper disable once InconsistentNaming
+	public static AmazonS3Client CreateAWSClient(S3Settings settings)
+	{
+		var scheme = settings.UseHttps ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
+		var port = settings.Port.HasValue ? $":{settings.Port}" : string.Empty;
 
-        return new AmazonS3Client(
-            new BasicAWSCredentials(settings.AccessKey, settings.SecretKey),
-            new AmazonS3Config
-            {
-                RegionEndpoint = RegionEndpoint.USEast1,
-                ServiceURL = $"{scheme}://{settings.EndPoint}{port}",
-                ForcePathStyle = true // MUST be true to work correctly with MinIO server
-            });
-    }
+		return new AmazonS3Client(
+			new BasicAWSCredentials(settings.AccessKey, settings.SecretKey),
+			new AmazonS3Config
+			{
+				RegionEndpoint = RegionEndpoint.USEast1,
+				ServiceURL = $"{scheme}://{settings.EndPoint}{port}",
+				ForcePathStyle = true, // MUST be true to work correctly with MinIO server
+			});
+	}
 
-    public static MinioClient CreateMinioClient(S3Settings settings)
-    {
-        var builder = new MinioClient();
-        var port = settings.Port;
-        if (port.HasValue) builder.WithEndpoint(settings.EndPoint, port.Value);
-        else builder.WithEndpoint(settings.EndPoint);
+	public static MinioClient CreateMinioClient(S3Settings settings)
+	{
+		var builder = new MinioClient();
+		var port = settings.Port;
+		if (port.HasValue)
+		{
+			builder.WithEndpoint(settings.EndPoint, port.Value);
+		}
+		else
+		{
+			builder.WithEndpoint(settings.EndPoint);
+		}
 
-        return builder
-            .WithCredentials(settings.AccessKey, settings.SecretKey)
-            .WithSSL(settings.UseHttps)
-            .Build();
-    }
+		return builder
+			.WithCredentials(settings.AccessKey, settings.SecretKey)
+			.WithSSL(settings.UseHttps)
+			.Build();
+	}
 
-    public static S3Client CreateStoragesClient(S3Settings settings) => new(settings);
+	public static S3Client CreateStoragesClient(S3Settings settings)
+	{
+		return new S3Client(settings);
+	}
 
-    public static void EnsureBucketExists(S3Client client, CancellationToken cancellation)
-    {
-        if (client.IsBucketExists(cancellation).GetAwaiter().GetResult()) return;
+	public static void EnsureBucketExists(S3Client client, CancellationToken cancellation)
+	{
+		if (client.IsBucketExists(cancellation).GetAwaiter().GetResult())
+		{
+			return;
+		}
 
-        client.CreateBucket(cancellation).GetAwaiter().GetResult();
-    }
+		client.CreateBucket(cancellation).GetAwaiter().GetResult();
+	}
 
-    public static void EnsureFileExists(
-        IConfiguration config, S3Client client, string fileName,
-        CancellationToken cancellation)
-    {
-        var fileData = ReadBigFile(config);
-        fileData.Seek(0, SeekOrigin.Begin);
+	public static void EnsureFileExists(
+		IConfiguration config,
+		S3Client client,
+		string fileName,
+		CancellationToken cancellation)
+	{
+		var fileData = ReadBigFile(config);
+		fileData.Seek(0, SeekOrigin.Begin);
 
-        var result = client
-            .UploadFile(fileName, "application/pdf", fileData, cancellation)
-            .GetAwaiter()
-            .GetResult();
+		var result = client
+			.UploadFile(fileName, "application/pdf", fileData, cancellation)
+			.GetAwaiter()
+			.GetResult();
 
-        if (!result) throw new Exception("File isn't uploaded");
-    }
+		if (!result)
+		{
+			throw new Exception("File isn't uploaded");
+		}
+	}
 
-    public static byte[] ReadBigArray(IConfiguration config)
-    {
-        var filePath = config.GetValue<string>("BigFilePath");
+	public static byte[] ReadBigArray(IConfiguration config)
+	{
+		var filePath = config.GetValue<string>("BigFilePath");
 
-        return !string.IsNullOrEmpty(filePath) && File.Exists(filePath)
-            ? File.ReadAllBytes(filePath)
-            : GetByteArray(123 * 1024 * 1024); // 123 Mb
-    }
+		return !string.IsNullOrEmpty(filePath) && File.Exists(filePath)
+			? File.ReadAllBytes(filePath)
+			: GetByteArray(123 * 1024 * 1024); // 123 Mb
+	}
 
-    public static InputStream ReadBigFile(IConfiguration config)
-    {
-        return new InputStream(ReadBigArray(config));
-    }
+	public static InputStream ReadBigFile(IConfiguration config)
+	{
+		return new InputStream(ReadBigArray(config));
+	}
 
-    public static IConfiguration ReadConfiguration() => new ConfigurationBuilder()
-        .AddJsonFile("appsettings.json", false)
-        .Build();
+	public static IConfiguration ReadConfiguration()
+	{
+		return new ConfigurationBuilder()
+			.AddJsonFile("appsettings.json", false)
+			.Build();
+	}
 
-    public static async Task<int> ReadStreamMock(Stream input, byte[] buffer, CancellationToken cancellation)
-    {
-        var result = 0;
-        while (await input.ReadAsync(buffer, cancellation) != 0)
-        {
-            result++;
-        }
+	public static async Task<int> ReadStreamMock(Stream input, byte[] buffer, CancellationToken cancellation)
+	{
+		var result = 0;
+		while (await input.ReadAsync(buffer, cancellation) != 0)
+		{
+			result++;
+		}
 
-        await input.DisposeAsync();
+		await input.DisposeAsync();
 
-        return result;
-    }
+		return result;
+	}
 
-    public static S3Settings ReadSettings(IConfiguration config)
-    {
-        var settings = config.GetRequiredSection("S3Storage").Get<S3Settings>();
-        if (settings == null || string.IsNullOrEmpty(settings.EndPoint))
-        {
-            throw new Exception("S3Storage configuration is not found");
-        }
+	public static S3Settings ReadSettings(IConfiguration config)
+	{
+		var settings = config.GetRequiredSection("S3Storage").Get<S3Settings>();
+		if (settings == null || string.IsNullOrEmpty(settings.EndPoint))
+		{
+			throw new Exception("S3Storage configuration is not found");
+		}
 
-        var isContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER");
-        if (isContainer != null && bool.TryParse(isContainer, out var value) && value)
-        {
-            settings = new S3Settings
-            {
-                AccessKey = settings.AccessKey,
-                Bucket = settings.Bucket,
-                EndPoint = "host.docker.internal",
-                Port = settings.Port,
-                Region = settings.Region,
-                SecretKey = settings.SecretKey,
-                Service = settings.Service,
-                UseHttp2 = settings.UseHttp2,
-                UseHttps = settings.UseHttps,
-            };
-        }
+		var isContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER");
+		if (isContainer != null && bool.TryParse(isContainer, out var value) && value)
+		{
+			settings = new S3Settings
+			{
+				AccessKey = settings.AccessKey,
+				Bucket = settings.Bucket,
+				EndPoint = "host.docker.internal",
+				Port = settings.Port,
+				Region = settings.Region,
+				SecretKey = settings.SecretKey,
+				Service = settings.Service,
+				UseHttp2 = settings.UseHttp2,
+				UseHttps = settings.UseHttps,
+			};
+		}
 
-        return settings;
-    }
+		return settings;
+	}
 
-    private static byte[] GetByteArray(int size)
-    {
-        var random = Random.Shared;
-        var bytes = new byte[size];
-        for (var i = 0; i < bytes.Length; i++)
-        {
-            bytes[i] = (byte) random.Next();
-        }
+	private static byte[] GetByteArray(int size)
+	{
+		var random = Random.Shared;
+		var bytes = new byte[size];
+		for (var i = 0; i < bytes.Length; i++)
+		{
+			bytes[i] = (byte)random.Next();
+		}
 
-        return bytes;
-    }
+		return bytes;
+	}
 }

--- a/src/Storage.Benchmark/Utils/InputStream.cs
+++ b/src/Storage.Benchmark/Utils/InputStream.cs
@@ -2,42 +2,55 @@
 
 internal sealed class InputStream : Stream
 {
-    public override bool CanRead => true;
-    public override bool CanSeek => true;
-    public override bool CanWrite => false;
+	private readonly Stream _baseStream;
 
-    private readonly Stream _baseStream;
+	public InputStream(byte[] data)
+	{
+		_baseStream = new MemoryStream();
+		_baseStream.Write(data);
+	}
 
-    public InputStream(byte[] data)
-    {
-        _baseStream = new MemoryStream();
-        _baseStream.Write(data);
-    }
+	public override long Position
+	{
+		get => _baseStream.Position;
+		set => _baseStream.Position = value;
+	}
 
-    public override void Close()
-    {
-        _baseStream.Seek(0, SeekOrigin.Begin);
-    }
+	public override bool CanRead => true;
 
-    #region Contract
+	public override bool CanSeek => true;
 
-    public override long Length => _baseStream.Length;
+	public override bool CanWrite => false;
 
-    public override long Position
-    {
-        get => _baseStream.Position;
-        set => _baseStream.Position = value;
-    }
+	public override long Length => _baseStream.Length;
 
-    public override void Flush() => _baseStream.Flush();
+	public override void Close()
+	{
+		_baseStream.Seek(0, SeekOrigin.Begin);
+	}
 
-    public override int Read(byte[] buffer, int offset, int count) => _baseStream.Read(buffer, offset, count);
+	public override void Flush()
+	{
+		_baseStream.Flush();
+	}
 
-    public override long Seek(long offset, SeekOrigin origin) => _baseStream.Seek(offset, origin);
+	public override int Read(byte[] buffer, int offset, int count)
+	{
+		return _baseStream.Read(buffer, offset, count);
+	}
 
-    public override void SetLength(long value) => _baseStream.SetLength(value);
+	public override long Seek(long offset, SeekOrigin origin)
+	{
+		return _baseStream.Seek(offset, origin);
+	}
 
-    public override void Write(byte[] buffer, int offset, int count) => _baseStream.Write(buffer, offset, count);
+	public override void SetLength(long value)
+	{
+		_baseStream.SetLength(value);
+	}
 
-    #endregion
+	public override void Write(byte[] buffer, int offset, int count)
+	{
+		_baseStream.Write(buffer, offset, count);
+	}
 }

--- a/src/Storage.Tests/BucketShould.cs
+++ b/src/Storage.Tests/BucketShould.cs
@@ -5,106 +5,115 @@ namespace Storage.Tests;
 
 public sealed class BucketShould : IClassFixture<StorageFixture>
 {
-    private readonly CancellationToken _cancellation;
-    private readonly S3Client _client;
-    private readonly StorageFixture _fixture;
+	private readonly CancellationToken _cancellation;
+	private readonly StorageFixture _fixture;
+	private readonly S3Client _client;
 
-    public BucketShould(StorageFixture fixture)
-    {
-        _cancellation = CancellationToken.None;
-        _client = fixture.S3Client;
-        _fixture = fixture;
-    }
+	public BucketShould(StorageFixture fixture)
+	{
+		_cancellation = CancellationToken.None;
+		_client = fixture.S3Client;
+		_fixture = fixture;
+	}
 
-    [Fact]
-    public async Task CreateBucket()
-    {
-        var settings = _fixture.Settings;
+	[Fact]
+	public async Task CreateBucket()
+	{
+		var settings = _fixture.Settings;
 
-        // don't use using here
-        var client = new S3Client(new S3Settings
-        {
-            AccessKey = settings.AccessKey,
-            Bucket = _fixture.Create<string>(),
-            EndPoint = settings.EndPoint,
-            Port = settings.Port,
-            SecretKey = settings.SecretKey,
-            UseHttps = settings.UseHttps
-        }, _fixture.HttpClient);
+		// don't use using here
+		var client =
+			new S3Client(
+				new S3Settings
+				{
+					AccessKey = settings.AccessKey,
+					Bucket = _fixture.Create<string>(),
+					EndPoint = settings.EndPoint,
+					Port = settings.Port,
+					SecretKey = settings.SecretKey,
+					UseHttps = settings.UseHttps,
+				},
+				_fixture.HttpClient);
 
-        var bucketCreateResult = await client.CreateBucket(_cancellation);
+		var bucketCreateResult = await client.CreateBucket(_cancellation);
 
-        bucketCreateResult
-            .Should().BeTrue();
+		bucketCreateResult
+			.Should().BeTrue();
 
-        await DeleteTestBucket(client);
-    }
+		await DeleteTestBucket(client);
+	}
 
-    [Fact]
-    public async Task BeExists()
-    {
-        var bucketExistsResult = await _client.IsBucketExists(_cancellation);
+	[Fact]
+	public async Task BeExists()
+	{
+		var bucketExistsResult = await _client.IsBucketExists(_cancellation);
 
-        bucketExistsResult
-            .Should().BeTrue();
-    }
+		bucketExistsResult
+			.Should().BeTrue();
+	}
 
-    [Fact]
-    public async Task BeNotExists()
-    {
-        var settings = _fixture.Settings;
+	[Fact]
+	public async Task BeNotExists()
+	{
+		var settings = _fixture.Settings;
 
-        // don't dispose it
-        var client = new S3Client(new S3Settings
-        {
-            AccessKey = settings.AccessKey,
-            Bucket = _fixture.Create<string>(),
-            EndPoint = settings.EndPoint,
-            Port = settings.Port,
-            SecretKey = settings.SecretKey,
-            UseHttps = settings.UseHttps
-        }, _fixture.HttpClient);
+		// don't dispose it
+		var client =
+			new S3Client(
+				new S3Settings
+				{
+					AccessKey = settings.AccessKey,
+					Bucket = _fixture.Create<string>(),
+					EndPoint = settings.EndPoint,
+					Port = settings.Port,
+					SecretKey = settings.SecretKey,
+					UseHttps = settings.UseHttps,
+				},
+				_fixture.HttpClient);
 
-        var bucketExistsResult = await client.IsBucketExists(_cancellation);
+		var bucketExistsResult = await client.IsBucketExists(_cancellation);
 
-        bucketExistsResult
-            .Should().BeFalse();
-    }
+		bucketExistsResult
+			.Should().BeFalse();
+	}
 
-    [Fact]
-    public Task NotThrowIfCreateBucketAlreadyExists()
-    {
-        return _client
-            .Invoking(client => client.CreateBucket(_cancellation))
-            .Should().NotThrowAsync();
-    }
+	[Fact]
+	public Task NotThrowIfCreateBucketAlreadyExists()
+	{
+		return _client
+			.Invoking(client => client.CreateBucket(_cancellation))
+			.Should().NotThrowAsync();
+	}
 
-    [Fact]
-    public Task NotThrowIfDeleteNotExistsBucket()
-    {
-        var settings = _fixture.Settings;
+	[Fact]
+	public Task NotThrowIfDeleteNotExistsBucket()
+	{
+		var settings = _fixture.Settings;
 
-        // don't use using here
-        var client = new S3Client(new S3Settings
-        {
-            AccessKey = settings.AccessKey,
-            Bucket = _fixture.Create<string>(),
-            EndPoint = settings.EndPoint,
-            Port = settings.Port,
-            SecretKey = settings.SecretKey,
-            UseHttps = settings.UseHttps
-        }, _fixture.HttpClient);
+		// don't use using here
+		var client =
+			new S3Client(
+				new S3Settings
+				{
+					AccessKey = settings.AccessKey,
+					Bucket = _fixture.Create<string>(),
+					EndPoint = settings.EndPoint,
+					Port = settings.Port,
+					SecretKey = settings.SecretKey,
+					UseHttps = settings.UseHttps,
+				},
+				_fixture.HttpClient);
 
-        return client
-            .Invoking(c => c.DeleteBucket(_cancellation))
-            .Should().NotThrowAsync();
-    }
+		return client
+			.Invoking(c => c.DeleteBucket(_cancellation))
+			.Should().NotThrowAsync();
+	}
 
-    private async Task DeleteTestBucket(S3Client client)
-    {
-        var bucketDeleteResult = await client.DeleteBucket(_cancellation);
+	private async Task DeleteTestBucket(S3Client client)
+	{
+		var bucketDeleteResult = await client.DeleteBucket(_cancellation);
 
-        bucketDeleteResult
-            .Should().BeTrue();
-    }
+		bucketDeleteResult
+			.Should().BeTrue();
+	}
 }

--- a/src/Storage.Tests/ClientShould.cs
+++ b/src/Storage.Tests/ClientShould.cs
@@ -1,35 +1,36 @@
-﻿using FluentAssertions;
+﻿using System.Text.Json;
+using FluentAssertions;
 using Storage.Tests.Mocks;
 
 namespace Storage.Tests;
 
 public sealed class ClientShould : IClassFixture<StorageFixture>
 {
-    private readonly S3Client _client;
-    private readonly StorageFixture _fixture;
+	private readonly S3Client _client;
+	private readonly StorageFixture _fixture;
 
-    public ClientShould(StorageFixture fixture)
-    {
-        _fixture = fixture;
-        _client = fixture.S3Client;
-    }
+	public ClientShould(StorageFixture fixture)
+	{
+		_fixture = fixture;
+		_client = fixture.S3Client;
+	}
 
-    [Fact]
-    public void DeserializeSettingsJson()
-    {
-        var expected = _fixture.Settings;
-        
-        var json = System.Text.Json.JsonSerializer.Serialize(expected);
-        var actual = System.Text.Json.JsonSerializer.Deserialize<S3Settings>(json);
+	[Fact]
+	public void DeserializeSettingsJson()
+	{
+		var expected = _fixture.Settings;
 
-        actual.Should().BeEquivalentTo(expected);
-    }
-    
-    [Fact]
-    public void HasValidInfo()
-    {
-        _client
-            .Bucket
-            .Should().Be(_fixture.Settings.Bucket);
-    }
+		var json = JsonSerializer.Serialize(expected);
+		var actual = JsonSerializer.Deserialize<S3Settings>(json);
+
+		actual.Should().BeEquivalentTo(expected);
+	}
+
+	[Fact]
+	public void HasValidInfo()
+	{
+		_client
+			.Bucket
+			.Should().Be(_fixture.Settings.Bucket);
+	}
 }

--- a/src/Storage.Tests/Mocks/StorageFixture.cs
+++ b/src/Storage.Tests/Mocks/StorageFixture.cs
@@ -9,8 +9,6 @@ public sealed class StorageFixture : IDisposable
 
 	private const int DefaultByteArraySize = 1 * 1024 * 1024; // 7Mb
 
-	private readonly HttpClient _httpClient;
-	private readonly S3Client _s3Client;
 	private Fixture? _fixture;
 
 	public StorageFixture()
@@ -25,7 +23,7 @@ public sealed class StorageFixture : IDisposable
 		var environmentHttps = Environment.GetEnvironmentVariable("STORAGE_HTTPS");
 		var https = !string.IsNullOrEmpty(environmentHttps) && bool.Parse(environmentHttps);
 
-		var settings = new S3Settings
+		Settings = new S3Settings
 		{
 			AccessKey = Environment.GetEnvironmentVariable("STORAGE_KEY") ?? "ROOTUSER",
 			Bucket = Environment.GetEnvironmentVariable("STORAGE_BUCKET") ?? "reconfig",
@@ -35,11 +33,17 @@ public sealed class StorageFixture : IDisposable
 			UseHttps = https,
 		};
 
-		_httpClient = new HttpClient();
-		_s3Client = new S3Client(settings);
+		HttpClient = new HttpClient();
+		S3Client = new S3Client(Settings);
 	}
 
-	public Fixture Mocks => _fixture ??= new Fixture();
+	internal S3Settings Settings { get; }
+
+	internal S3Client S3Client { get; }
+
+	internal HttpClient HttpClient { get; }
+
+	internal Fixture Mocks => _fixture ??= new Fixture();
 
 	public static byte[] GetByteArray(int size = DefaultByteArraySize)
 	{
@@ -67,8 +71,8 @@ public sealed class StorageFixture : IDisposable
 
 	public void Dispose()
 	{
-		_httpClient.Dispose();
-		_s3Client.Dispose();
+		HttpClient.Dispose();
+		S3Client.Dispose();
 	}
 
 	public T Create<T>()

--- a/src/Storage.Tests/ObjectShould.cs
+++ b/src/Storage.Tests/ObjectShould.cs
@@ -7,433 +7,444 @@ namespace Storage.Tests;
 
 public sealed class ObjectShould : IClassFixture<StorageFixture>
 {
-    private readonly CancellationToken _ct;
-    private readonly S3Client _client;
-    private readonly StorageFixture _fixture;
-    private readonly S3Client _notExistsBucketClient; // don't dispose it
-
-    public ObjectShould(StorageFixture fixture)
-    {
-        _ct = CancellationToken.None;
-        _client = fixture.S3Client;
-        _fixture = fixture;
-
-        var settings = _fixture.Settings;
-        _notExistsBucketClient = new S3Client(new S3Settings
-        {
-            AccessKey = settings.AccessKey,
-            Bucket = _fixture.Create<string>(),
-            EndPoint = settings.EndPoint,
-            Port = settings.Port,
-            SecretKey = settings.SecretKey,
-            UseHttps = settings.UseHttps
-        }, _fixture.HttpClient);
-    }
-
-    [Fact]
-    public async Task AllowParallelUploadMultipleFiles()
-    {
-        const int parallelization = 10;
-
-        var file = _fixture.Create<string>();
-        var tasks = new Task<bool>[parallelization];
-        for (var i = 0; i < parallelization; i++)
-        {
-            var fileData = GetByteStream(12 * 1024 * 1024);
-            var fileName = $"{file}-{i}";
-            tasks[i] = Task.Run(async () =>
-            {
-                await _client.UploadFile(fileName, StreamContentType, fileData, _ct);
-                if (!await _client.IsFileExists(fileName, _ct)) return false;
-                await _client.DeleteFile(fileName, _ct);
-                return true;
-            }, _ct);
-        }
-
-        await Task.WhenAll(tasks);
-
-        foreach (var task in tasks)
-        {
-            task
-                .IsCompletedSuccessfully
-                .Should().BeTrue();
-
-            task
-                .Result
-                .Should().BeTrue();
-
-            task.Dispose();
-        }
-    }
-
-    [Fact]
-    public void BuildUrl()
-    {
-        var fileName = _fixture.Create<string>();
-
-        _client
-            .Invoking(client => client.BuildFileUrl(fileName, TimeSpan.FromSeconds(100)))
-            .Should().NotThrow()
-            .Which.Should().NotBeNull();
-    }
-
-    [Fact]
-    public async Task BeExists()
-    {
-        var fileName = await CreateTestFile();
-        var fileExistsResult = await _client.IsFileExists(fileName, _ct);
-
-        fileExistsResult
-            .Should().BeTrue();
-
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public async Task BeNotExists()
-    {
-        var fileExistsResult = await _client.IsFileExists(_fixture.Create<string>(), _ct);
-
-        fileExistsResult
-            .Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task DeleteFile()
-    {
-        var fileName = await CreateTestFile();
-
-        await _client
-            .Invoking(client => client.DeleteFile(fileName, _ct))
-            .Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task DisposeFileStream()
-    {
-        var fileName = await CreateTestFile();
-        using var fileGetResult = await _client.GetFile(fileName, _ct);
+	private readonly S3Client _client;
+	private readonly CancellationToken _ct;
+	private readonly StorageFixture _fixture;
+	private readonly S3Client _notExistsBucketClient; // don't dispose it
+
+	public ObjectShould(StorageFixture fixture)
+	{
+		_ct = CancellationToken.None;
+		_client = fixture.S3Client;
+		_fixture = fixture;
+
+		var settings = _fixture.Settings;
+		_notExistsBucketClient = new S3Client(
+			new S3Settings
+			{
+				AccessKey = settings.AccessKey,
+				Bucket = _fixture.Create<string>(),
+				EndPoint = settings.EndPoint,
+				Port = settings.Port,
+				SecretKey = settings.SecretKey,
+				UseHttps = settings.UseHttps,
+			},
+			_fixture.HttpClient);
+	}
+
+	[Fact]
+	public async Task AllowParallelUploadMultipleFiles()
+	{
+		const int parallelization = 10;
+
+		var file = _fixture.Create<string>();
+		var tasks = new Task<bool>[parallelization];
+		for (var i = 0; i < parallelization; i++)
+		{
+			var fileData = GetByteStream(12 * 1024 * 1024);
+			var fileName = $"{file}-{i}";
+			tasks[i] = Task.Run(
+				async () =>
+			{
+				await _client.UploadFile(fileName, StreamContentType, fileData, _ct);
+				if (!await _client.IsFileExists(fileName, _ct))
+				{
+					return false;
+				}
+
+				await _client.DeleteFile(fileName, _ct);
+				return true;
+			},
+				_ct);
+		}
+
+		await Task.WhenAll(tasks);
+
+		foreach (var task in tasks)
+		{
+			task
+				.IsCompletedSuccessfully
+				.Should().BeTrue();
+
+			task
+				.Result
+				.Should().BeTrue();
+
+			task.Dispose();
+		}
+	}
+
+	[Fact]
+	public void BuildUrl()
+	{
+		var fileName = _fixture.Create<string>();
+
+		_client
+			.Invoking(client => client.BuildFileUrl(fileName, TimeSpan.FromSeconds(100)))
+			.Should().NotThrow()
+			.Which.Should().NotBeNull();
+	}
+
+	[Fact]
+	public async Task BeExists()
+	{
+		var fileName = await CreateTestFile();
+		var fileExistsResult = await _client.IsFileExists(fileName, _ct);
+
+		fileExistsResult
+			.Should().BeTrue();
+
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public async Task BeNotExists()
+	{
+		var fileExistsResult = await _client.IsFileExists(_fixture.Create<string>(), _ct);
+
+		fileExistsResult
+			.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task DeleteFile()
+	{
+		var fileName = await CreateTestFile();
 
-        var fileStream = await fileGetResult.GetStream(_ct);
-        await fileStream.DisposeAsync();
+		await _client
+			.Invoking(client => client.DeleteFile(fileName, _ct))
+			.Should().NotThrowAsync();
+	}
 
-        await DeleteTestFile(fileName);
-    }
+	[Fact]
+	public async Task DisposeFileStream()
+	{
+		var fileName = await CreateTestFile();
+		using var fileGetResult = await _client.GetFile(fileName, _ct);
 
-    [Fact]
-    public async Task DisposeStorageFile()
-    {
-        var fileName = await CreateTestFile();
-        using var fileGetResult = await _client.GetFile(fileName, _ct);
+		var fileStream = await fileGetResult.GetStream(_ct);
+		await fileStream.DisposeAsync();
 
-        // ReSharper disable once MethodHasAsyncOverload
-        fileGetResult.Dispose();
+		await DeleteTestFile(fileName);
+	}
 
-        await DeleteTestFile(fileName);
-    }
+	[Fact]
+	public async Task DisposeStorageFile()
+	{
+		var fileName = await CreateTestFile();
+		using var fileGetResult = await _client.GetFile(fileName, _ct);
 
-    [Fact]
-    public async Task GetFileUrl()
-    {
-        var fileName = await CreateTestFile();
+		// ReSharper disable once MethodHasAsyncOverload
+		fileGetResult.Dispose();
 
-        var url = await _client.GetFileUrl(fileName, TimeSpan.FromSeconds(600), _ct);
+		await DeleteTestFile(fileName);
+	}
 
-        url.Should().NotBeNull();
+	[Fact]
+	public async Task GetFileUrl()
+	{
+		var fileName = await CreateTestFile();
 
-        using var response = await _fixture.HttpClient.GetAsync(url, _ct);
+		var url = await _client.GetFileUrl(fileName, TimeSpan.FromSeconds(600), _ct);
 
-        await DeleteTestFile(fileName);
+		url.Should().NotBeNull();
 
-        response
-            .IsSuccessStatusCode
-            .Should().BeTrue(response.ReasonPhrase);
-    }
+		using var response = await _fixture.HttpClient.GetAsync(url, _ct);
 
-    [Fact]
-    public async Task GetFileUrlWithCyrillicName()
-    {
-        var fileName = await CreateTestFile($"при(ве)+т_как23дела{Guid.NewGuid()}.pdf");
+		await DeleteTestFile(fileName);
 
-        var url = await _client.GetFileUrl(fileName, TimeSpan.FromSeconds(600), _ct);
+		response
+			.IsSuccessStatusCode
+			.Should().BeTrue(response.ReasonPhrase);
+	}
 
-        url.Should().NotBeNull();
+	[Fact]
+	public async Task GetFileUrlWithCyrillicName()
+	{
+		var fileName = await CreateTestFile($"при(ве)+т_как23дела{Guid.NewGuid()}.pdf");
 
-        using var response = await _fixture.HttpClient.GetAsync(url, _ct);
+		var url = await _client.GetFileUrl(fileName, TimeSpan.FromSeconds(600), _ct);
+
+		url.Should().NotBeNull();
+
+		using var response = await _fixture.HttpClient.GetAsync(url, _ct);
+
+		await DeleteTestFile(fileName);
 
-        await DeleteTestFile(fileName);
+		response
+			.IsSuccessStatusCode
+			.Should().BeTrue(response.ReasonPhrase);
+	}
 
-        response
-            .IsSuccessStatusCode
-            .Should().BeTrue(response.ReasonPhrase);
-    }
-
-    [Fact]
-    public async Task HasValidInformation()
-    {
-        const int length = 1 * 1024 * 1024;
-        const string contentType = "video/mp4";
-
-        var fileName = await CreateTestFile(contentType: contentType);
-        using var fileGetResult = await _client.GetFile(fileName, _ct);
-
-        ((bool) fileGetResult).Should().BeTrue();
-
-        fileGetResult
-            .ContentType
-            .Should().Be(contentType);
-
-        fileGetResult
-            .Exists
-            .Should().BeTrue();
-
-        fileGetResult
-            .Length
-            .Should().Be(length);
-
-        fileGetResult
-            .StatusCode
-            .Should().Be(HttpStatusCode.OK);
-
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public async Task HasValidStreamInformation()
-    {
-        const int length = 1 * 1024 * 1024;
-        var fileName = await CreateTestFile(size: length);
-        using var fileGetResult = await _client.GetFile(fileName, _ct);
-
-        var fileStream = await fileGetResult.GetStream(_ct);
-
-        fileStream.CanRead.Should().BeTrue();
-        fileStream.CanSeek.Should().BeFalse();
-        fileStream.CanWrite.Should().BeFalse();
-        fileStream.Length.Should().Be(length);
-
-        fileStream
-            .Invoking(stream => stream.Position)
-            .Should().Throw<NotSupportedException>();
-
-        await fileStream.DisposeAsync();
-        await fileStream.DisposeAsync();
-
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public async Task ListFiles()
-    {
-        const int count = 2;
-        var noiseFiles = new List<string>();
-        var expectedFileNames = new string[count];
-        var prefix = _fixture.Create<string>();
-
-        for (var i = 0; i < count; i++)
-        {
-            var fileName = $"{prefix}#{_fixture.Create<string>()}";
-            expectedFileNames[i] = await CreateTestFile(fileName: fileName, size: 1024);
-            noiseFiles.Add(await CreateTestFile());
-        }
-
-        var actualFileNames = new List<string>();
-        await foreach (var file in _client.List(prefix, _ct))
-        {
-            actualFileNames.Add(file);
-        }
-
-        actualFileNames
-            .Should().Contain(expectedFileNames);
-
-        foreach (var fileName in expectedFileNames.Concat(noiseFiles))
-        {
-            await DeleteTestFile(fileName);
-        }
-    }
-
-    [Fact]
-    public async Task PutByteArray()
-    {
-        var fileName = _fixture.Create<string>();
-        var data = GetByteArray(15000);
-        var filePutResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
-
-        filePutResult
-            .Should().BeTrue();
-
-        await EnsureFileSame(fileName, data);
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public async Task PutStream()
-    {
-        var fileName = _fixture.Create<string>();
-        var data = GetByteStream(15000);
-        var filePutResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
-
-        filePutResult
-            .Should().BeTrue();
-
-        await EnsureFileSame(fileName, data);
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public async Task Upload()
-    {
-        var fileName = _fixture.Create<string>();
-        using var data = GetByteStream(12 * 1024 * 1024); // 12 Mb
-        var filePutResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
-
-        filePutResult
-            .Should().BeTrue();
-
-        await EnsureFileSame(fileName, data.ToArray());
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public async Task UploadCyrillicName()
-    {
-        var fileName = $"при(ве)+т_как23дела{Guid.NewGuid()}.pdf";
-        using var data = GetByteStream();
-        var uploadResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
-
-        await DeleteTestFile(fileName);
-
-        uploadResult
-            .Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task NotThrowIfFileAlreadyExists()
-    {
-        var fileName = await CreateTestFile();
-        await _client
-            .Invoking(client => client.UploadFile(fileName, StreamContentType, GetByteStream(), _ct))
-            .Should().NotThrowAsync();
-
-        await DeleteTestFile(fileName);
-    }
-
-    [Fact]
-    public Task NotThrowIfFileExistsWithNotExistsBucket()
-    {
-        return _notExistsBucketClient
-            .Invoking(client => client.IsFileExists(_fixture.Create<string>(), _ct))
-            .Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task NotThrowIfFileGetUrlWithNotExistsBucket()
-    {
-        var result = await _notExistsBucketClient
-            .Invoking(client => client.GetFileUrl(_fixture.Create<string>(), TimeSpan.FromSeconds(100), _ct))
-            .Should().NotThrowAsync();
-
-        result
-            .Which
-            .Should().BeNull();
-    }
-
-    [Fact]
-    public async Task NotThrowIfFileGetWithNotExistsBucket()
-    {
-        var result = await _notExistsBucketClient
-            .Invoking(client => client.GetFile(_fixture.Create<string>(), _ct))
-            .Should().NotThrowAsync();
-
-        var getFileResult = result.Which;
-
-        ((bool) getFileResult).Should().BeFalse();
-
-        getFileResult
-            .Exists
-            .Should().BeFalse();
-    }
-
-    [Fact]
-    public async Task NotThrowIfGetNotExistsFile()
-    {
-        var fileName = _fixture.Create<string>();
-        await _client
-            .Invoking(client => client.GetFile(fileName, _ct))
-            .Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public Task NotThrowIfDeleteFileNotExists()
-    {
-        return _client
-            .Invoking(client => client.DeleteFile(_fixture.Create<string>(), _ct))
-            .Should().NotThrowAsync();
-    }
-
-    [Fact]
-    public async Task ThrowIfBucketNotExists()
-    {
-        var fileArray = GetByteArray();
-        var fileName = _fixture.Create<string>();
-        var fileStream = GetByteStream();
-
-        await _notExistsBucketClient
-            .Invoking(client => client.DeleteFile(fileName, _ct))
-            .Should().ThrowAsync<HttpRequestException>();
-
-        await _notExistsBucketClient
-            .Invoking(client => client.UploadFile(fileName, StreamContentType, fileStream, _ct))
-            .Should().ThrowAsync<HttpRequestException>();
-
-        await _notExistsBucketClient
-            .Invoking(client => client.UploadFile(fileName, StreamContentType, fileArray, _ct))
-            .Should().ThrowAsync<HttpRequestException>();
-    }
-
-    private async Task<string> CreateTestFile(
-        string? fileName = null,
-        string contentType = StreamContentType,
-        int? size = null)
-    {
-        fileName ??= _fixture.Create<string>();
-        using var data = GetByteStream(size ?? 1 * 1024 * 1024); // 1 Mb
-
-        var uploadResult = await _client.UploadFile(fileName, contentType, data, _ct);
-
-        uploadResult
-            .Should().BeTrue();
-
-        return fileName;
-    }
-
-    private async Task EnsureFileSame(string fileName, byte[] expectedBytes)
-    {
-        using var getFileResult = await _client.GetFile(fileName, _ct);
-
-        using var memoryStream = GetEmptyByteStream(getFileResult.Length);
-        var stream = await getFileResult.GetStream(_ct);
-        await stream.CopyToAsync(memoryStream, _ct);
-
-        memoryStream
-            .ToArray().SequenceEqual(expectedBytes)
-            .Should().BeTrue();
-    }
-
-    private async Task EnsureFileSame(string fileName, MemoryStream expectedBytes)
-    {
-        expectedBytes.Seek(0, SeekOrigin.Begin);
-
-        using var getFileResult = await _client.GetFile(fileName, _ct);
-
-        using var memoryStream = GetEmptyByteStream(getFileResult.Length);
-        var stream = await getFileResult.GetStream(_ct);
-        await stream.CopyToAsync(memoryStream, _ct);
-
-        memoryStream
-            .ToArray().SequenceEqual(expectedBytes.ToArray())
-            .Should().BeTrue();
-    }
-
-    private Task DeleteTestFile(string fileName) => _client.DeleteFile(fileName, _ct);
+	[Fact]
+	public async Task HasValidInformation()
+	{
+		const int length = 1 * 1024 * 1024;
+		const string contentType = "video/mp4";
+
+		var fileName = await CreateTestFile(contentType: contentType);
+		using var fileGetResult = await _client.GetFile(fileName, _ct);
+
+		((bool)fileGetResult).Should().BeTrue();
+
+		fileGetResult
+			.ContentType
+			.Should().Be(contentType);
+
+		fileGetResult
+			.Exists
+			.Should().BeTrue();
+
+		fileGetResult
+			.Length
+			.Should().Be(length);
+
+		fileGetResult
+			.StatusCode
+			.Should().Be(HttpStatusCode.OK);
+
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public async Task HasValidStreamInformation()
+	{
+		const int length = 1 * 1024 * 1024;
+		var fileName = await CreateTestFile(size: length);
+		using var fileGetResult = await _client.GetFile(fileName, _ct);
+
+		var fileStream = await fileGetResult.GetStream(_ct);
+
+		fileStream.CanRead.Should().BeTrue();
+		fileStream.CanSeek.Should().BeFalse();
+		fileStream.CanWrite.Should().BeFalse();
+		fileStream.Length.Should().Be(length);
+
+		fileStream
+			.Invoking(stream => stream.Position)
+			.Should().Throw<NotSupportedException>();
+
+		await fileStream.DisposeAsync();
+		await fileStream.DisposeAsync();
+
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public async Task ListFiles()
+	{
+		const int count = 2;
+		var noiseFiles = new List<string>();
+		var expectedFileNames = new string[count];
+		var prefix = _fixture.Create<string>();
+
+		for (var i = 0; i < count; i++)
+		{
+			var fileName = $"{prefix}#{_fixture.Create<string>()}";
+			expectedFileNames[i] = await CreateTestFile(fileName, size: 1024);
+			noiseFiles.Add(await CreateTestFile());
+		}
+
+		var actualFileNames = new List<string>();
+		await foreach (var file in _client.List(prefix, _ct))
+		{
+			actualFileNames.Add(file);
+		}
+
+		actualFileNames
+			.Should().Contain(expectedFileNames);
+
+		foreach (var fileName in expectedFileNames.Concat(noiseFiles))
+		{
+			await DeleteTestFile(fileName);
+		}
+	}
+
+	[Fact]
+	public async Task PutByteArray()
+	{
+		var fileName = _fixture.Create<string>();
+		var data = GetByteArray(15000);
+		var filePutResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
+
+		filePutResult
+			.Should().BeTrue();
+
+		await EnsureFileSame(fileName, data);
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public async Task PutStream()
+	{
+		var fileName = _fixture.Create<string>();
+		var data = GetByteStream(15000);
+		var filePutResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
+
+		filePutResult
+			.Should().BeTrue();
+
+		await EnsureFileSame(fileName, data);
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public async Task Upload()
+	{
+		var fileName = _fixture.Create<string>();
+		using var data = GetByteStream(12 * 1024 * 1024); // 12 Mb
+		var filePutResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
+
+		filePutResult
+			.Should().BeTrue();
+
+		await EnsureFileSame(fileName, data.ToArray());
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public async Task UploadCyrillicName()
+	{
+		var fileName = $"при(ве)+т_как23дела{Guid.NewGuid()}.pdf";
+		using var data = GetByteStream();
+		var uploadResult = await _client.UploadFile(fileName, StreamContentType, data, _ct);
+
+		await DeleteTestFile(fileName);
+
+		uploadResult
+			.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task NotThrowIfFileAlreadyExists()
+	{
+		var fileName = await CreateTestFile();
+		await _client
+			.Invoking(client => client.UploadFile(fileName, StreamContentType, GetByteStream(), _ct))
+			.Should().NotThrowAsync();
+
+		await DeleteTestFile(fileName);
+	}
+
+	[Fact]
+	public Task NotThrowIfFileExistsWithNotExistsBucket()
+	{
+		return _notExistsBucketClient
+			.Invoking(client => client.IsFileExists(_fixture.Create<string>(), _ct))
+			.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task NotThrowIfFileGetUrlWithNotExistsBucket()
+	{
+		var result = await _notExistsBucketClient
+			.Invoking(client => client.GetFileUrl(_fixture.Create<string>(), TimeSpan.FromSeconds(100), _ct))
+			.Should().NotThrowAsync();
+
+		result
+			.Which
+			.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task NotThrowIfFileGetWithNotExistsBucket()
+	{
+		var result = await _notExistsBucketClient
+			.Invoking(client => client.GetFile(_fixture.Create<string>(), _ct))
+			.Should().NotThrowAsync();
+
+		var getFileResult = result.Which;
+
+		((bool)getFileResult).Should().BeFalse();
+
+		getFileResult
+			.Exists
+			.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task NotThrowIfGetNotExistsFile()
+	{
+		var fileName = _fixture.Create<string>();
+		await _client
+			.Invoking(client => client.GetFile(fileName, _ct))
+			.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public Task NotThrowIfDeleteFileNotExists()
+	{
+		return _client
+			.Invoking(client => client.DeleteFile(_fixture.Create<string>(), _ct))
+			.Should().NotThrowAsync();
+	}
+
+	[Fact]
+	public async Task ThrowIfBucketNotExists()
+	{
+		var fileArray = GetByteArray();
+		var fileName = _fixture.Create<string>();
+		var fileStream = GetByteStream();
+
+		await _notExistsBucketClient
+			.Invoking(client => client.DeleteFile(fileName, _ct))
+			.Should().ThrowAsync<HttpRequestException>();
+
+		await _notExistsBucketClient
+			.Invoking(client => client.UploadFile(fileName, StreamContentType, fileStream, _ct))
+			.Should().ThrowAsync<HttpRequestException>();
+
+		await _notExistsBucketClient
+			.Invoking(client => client.UploadFile(fileName, StreamContentType, fileArray, _ct))
+			.Should().ThrowAsync<HttpRequestException>();
+	}
+
+	private async Task<string> CreateTestFile(
+		string? fileName = null,
+		string contentType = StreamContentType,
+		int? size = null)
+	{
+		fileName ??= _fixture.Create<string>();
+		using var data = GetByteStream(size ?? 1 * 1024 * 1024); // 1 Mb
+
+		var uploadResult = await _client.UploadFile(fileName, contentType, data, _ct);
+
+		uploadResult
+			.Should().BeTrue();
+
+		return fileName;
+	}
+
+	private async Task EnsureFileSame(string fileName, byte[] expectedBytes)
+	{
+		using var getFileResult = await _client.GetFile(fileName, _ct);
+
+		using var memoryStream = GetEmptyByteStream(getFileResult.Length);
+		var stream = await getFileResult.GetStream(_ct);
+		await stream.CopyToAsync(memoryStream, _ct);
+
+		memoryStream
+			.ToArray().SequenceEqual(expectedBytes)
+			.Should().BeTrue();
+	}
+
+	private async Task EnsureFileSame(string fileName, MemoryStream expectedBytes)
+	{
+		expectedBytes.Seek(0, SeekOrigin.Begin);
+
+		using var getFileResult = await _client.GetFile(fileName, _ct);
+
+		using var memoryStream = GetEmptyByteStream(getFileResult.Length);
+		var stream = await getFileResult.GetStream(_ct);
+		await stream.CopyToAsync(memoryStream, _ct);
+
+		memoryStream
+			.ToArray().SequenceEqual(expectedBytes.ToArray())
+			.Should().BeTrue();
+	}
+
+	private Task DeleteTestFile(string fileName)
+	{
+		return _client.DeleteFile(fileName, _ct);
+	}
 }

--- a/src/Storage.Tests/Storage.Tests.csproj
+++ b/src/Storage.Tests/Storage.Tests.csproj
@@ -12,6 +12,10 @@
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="JunitXml.TestLogger" Version="3.0.124" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/Storage/S3Client.cs
+++ b/src/Storage/S3Client.cs
@@ -10,11 +10,13 @@ using static Storage.Utils.HashHelper;
 
 namespace Storage;
 
-[DebuggerDisplay("Client for '{_bucketName}'")]
+[DebuggerDisplay("Client for '{Bucket}'")]
 [SuppressMessage("ReSharper", "SwitchStatementHandlesSomeKnownEnumValuesWithDefault")]
 public sealed class S3Client
 {
     internal const int DefaultPartSize = 5 * 1024 * 1024; // 5 Mb
+
+    internal readonly string Bucket;
 
     private static readonly string[] _s3Headers = // trimmed, lower invariant, ordered
     {
@@ -23,7 +25,6 @@ public sealed class S3Client
         "x-amz-date",
     };
 
-    private readonly string _bucketName;
     private readonly string _bucket;
     private readonly string _endpoint;
     private readonly HttpHelper _http;
@@ -35,9 +36,9 @@ public sealed class S3Client
 
     public S3Client(S3Settings settings, HttpClient? client = null)
     {
-	    _bucketName = settings.Bucket;
+	    Bucket = settings.Bucket;
 
-	    var bucket = _bucketName.ToLowerInvariant();
+	    var bucket = Bucket.ToLowerInvariant();
 	    var scheme = settings.UseHttps ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
 	    var port = settings.Port.HasValue ? $":{settings.Port}" : string.Empty;
 

--- a/src/Storage/S3Client.cs
+++ b/src/Storage/S3Client.cs
@@ -12,6 +12,7 @@ namespace Storage;
 
 [DebuggerDisplay("Client for '{Bucket}'")]
 [SuppressMessage("ReSharper", "SwitchStatementHandlesSomeKnownEnumValuesWithDefault")]
+[SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:Fields should be private")]
 public sealed class S3Client
 {
     internal const int DefaultPartSize = 5 * 1024 * 1024; // 5 Mb
@@ -374,7 +375,7 @@ public sealed class S3Client
             }
         }
 
-        var result = response is {IsSuccessStatusCode: true, StatusCode: HttpStatusCode.OK}
+        var result = response is { IsSuccessStatusCode: true, StatusCode: HttpStatusCode.OK }
             ? response.Headers.ETag?.Tag
             : null;
 

--- a/src/Storage/S3File.cs
+++ b/src/Storage/S3File.cs
@@ -6,86 +6,95 @@ using System.Runtime.CompilerServices;
 namespace Storage;
 
 /// <summary>
-/// Wrapper around <see cref="HttpResponseMessage"/> with a data of a file from storage
+///     Wrapper around <see cref="HttpResponseMessage" /> with a data of a file from storage
 /// </summary>
 [DebuggerDisplay("{ToString()}")]
 public sealed class S3File : IDisposable
 {
-    /// <summary>
-    /// Type of file content in MIME
-    /// </summary>
-    /// <remarks>It will be take from header "Content-Type" of <see cref="HttpResponseMessage"/></remarks>
-    public string? ContentType
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _response.Content.Headers.ContentType?.MediaType;
-    }
+	private readonly HttpResponseMessage _response;
 
-    /// <summary>
-    /// Is the file data received successfully?
-    /// </summary>
-    public bool Exists
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _response.IsSuccessStatusCode;
-    }
+	internal S3File(HttpResponseMessage response)
+	{
+		_response = response;
+	}
 
-    /// <summary>
-    /// Length of file data
-    /// </summary>
-    /// <remarks>It will be take from header "Content-Length" of <see cref="HttpResponseMessage"/></remarks>
-    public long? Length
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _response.Content.Headers.ContentLength;
-    }
+	/// <summary>
+	///     Type of file content in MIME
+	/// </summary>
+	/// <remarks>It will be take from header "Content-Type" of <see cref="HttpResponseMessage" /></remarks>
+	public string? ContentType
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => _response.Content.Headers.ContentType?.MediaType;
+	}
 
-    /// <summary>
-    /// The code of storage response 
-    /// </summary>
-    public HttpStatusCode StatusCode
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _response.StatusCode;
-    }
+	/// <summary>
+	///     Is the file data received successfully?
+	/// </summary>
+	public bool Exists
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => _response.IsSuccessStatusCode;
+	}
 
-    private readonly HttpResponseMessage _response;
+	/// <summary>
+	///     Length of file data
+	/// </summary>
+	/// <remarks>It will be take from header "Content-Length" of <see cref="HttpResponseMessage" /></remarks>
+	public long? Length
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => _response.Content.Headers.ContentLength;
+	}
 
-    internal S3File(HttpResponseMessage response)
-    {
-        _response = response;
-    }
+	/// <summary>
+	///     The code of storage response
+	/// </summary>
+	public HttpStatusCode StatusCode
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => _response.StatusCode;
+	}
 
-    /// <summary>
-    /// Gets stream of the file data from <see cref="HttpResponseMessage"/>
-    /// </summary>
-    /// <returns>Stream of data</returns>
-    /// <remarks>When stream will be closed the <see cref="HttpResponseMessage"/> will be disposed</remarks>
-    public async Task<Stream> GetStream(CancellationToken cancellation)
-    {
-        if (!_response.IsSuccessStatusCode) return Stream.Null;
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static implicit operator bool(S3File file)
+	{
+		return file._response.IsSuccessStatusCode;
+	}
 
-        var stream = await _response.Content.ReadAsStreamAsync(cancellation).ConfigureAwait(false);
-        return new S3Stream(_response, stream);
-    }
+	public void Dispose()
+	{
+		_response.Dispose();
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator bool(S3File file) => file._response.IsSuccessStatusCode;
+	/// <summary>
+	///     Gets stream of the file data from <see cref="HttpResponseMessage" />
+	/// </summary>
+	/// <returns>Stream of data</returns>
+	/// <remarks>When stream will be closed the <see cref="HttpResponseMessage" /> will be disposed</remarks>
+	public async Task<Stream> GetStream(CancellationToken cancellation)
+	{
+		if (!_response.IsSuccessStatusCode)
+		{
+			return Stream.Null;
+		}
 
-    [ExcludeFromCodeCoverage]
-    public override string ToString()
-    {
-        if (_response.IsSuccessStatusCode) return $"OK (Length = {Length})";
+		var stream = await _response.Content.ReadAsStreamAsync(cancellation).ConfigureAwait(false);
+		return new S3Stream(_response, stream);
+	}
 
-        var reasonPhrase = _response.ReasonPhrase;
-        var statusCode = _response.StatusCode;
-        return string.IsNullOrEmpty(reasonPhrase)
-            ? $"{statusCode} ({(int) statusCode})"
-            : $"{statusCode} ({(int) statusCode}, '{reasonPhrase}')";
-    }
+	[ExcludeFromCodeCoverage]
+	public override string ToString()
+	{
+		if (_response.IsSuccessStatusCode)
+		{
+			return $"OK (Length = {Length})";
+		}
 
-    public void Dispose()
-    {
-        _response.Dispose();
-    }
+		var reasonPhrase = _response.ReasonPhrase;
+		var statusCode = _response.StatusCode;
+		return string.IsNullOrEmpty(reasonPhrase)
+			? $"{statusCode} ({(int)statusCode})"
+			: $"{statusCode} ({(int)statusCode}, '{reasonPhrase}')";
+	}
 }

--- a/src/Storage/S3Settings.cs
+++ b/src/Storage/S3Settings.cs
@@ -17,6 +17,6 @@ public sealed class S3Settings
     public string Service { get; init; } = "s3";
 
     public bool UseHttp2 { get; init; } = false;
-    
+
     public required bool UseHttps { get; init; }
 }

--- a/src/Storage/S3Stream.cs
+++ b/src/Storage/S3Stream.cs
@@ -4,74 +4,87 @@ namespace Storage;
 
 internal sealed class S3Stream : Stream
 {
-    public override long Length
-    {
-        get
-        {
-            _length ??= _response.Content.Headers.ContentLength ?? _stream.Length;
-            return _length.Value;
-        }
-    }
+	private readonly HttpResponseMessage _response;
+	private readonly Stream _stream;
+	private long? _length;
 
-    private long? _length;
-    private readonly Stream _stream;
-    private readonly HttpResponseMessage _response;
+	public S3Stream(HttpResponseMessage response, Stream stream)
+	{
+		_response = response;
+		_stream = stream;
+	}
 
-    public S3Stream(HttpResponseMessage response, Stream stream)
-    {
-        _response = response;
-        _stream = stream;
-    }
+	public override bool CanRead => _stream.CanRead;
 
-    protected override void Dispose(bool disposing)
-    {
-        _stream.Dispose();
-        _response.Dispose();
-    }
+	public override bool CanSeek => _stream.CanSeek;
 
-    #region Contract
+	public override bool CanWrite => _stream.CanWrite;
 
-    public override bool CanRead => _stream.CanRead;
+	public override long Length
+	{
+		get
+		{
+			_length ??= _response.Content.Headers.ContentLength ?? _stream.Length;
+			return _length.Value;
+		}
+	}
 
-    public override bool CanSeek => _stream.CanSeek;
+	[ExcludeFromCodeCoverage]
+	public override long Position
+	{
+		get => _stream.Position;
+		set => _stream.Position = value;
+	}
 
-    public override bool CanWrite => _stream.CanWrite;
+	public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+	{
+		return _stream.ReadAsync(buffer, offset, count, cancellationToken);
+	}
 
-    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-    {
-        return _stream.ReadAsync(buffer, offset, count, cancellationToken);
-    }
+	public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		return _stream.ReadAsync(buffer, cancellationToken);
+	}
 
-    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = new CancellationToken())
-    {
-        return _stream.ReadAsync(buffer, cancellationToken);
-    }
+	public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+	{
+		return _stream.CopyToAsync(destination, bufferSize, cancellationToken);
+	}
 
-    public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
-    {
-        return _stream.CopyToAsync(destination, bufferSize, cancellationToken);
-    }
+	[ExcludeFromCodeCoverage]
+	public override void Flush()
+	{
+		_stream.Flush();
+	}
 
-    [ExcludeFromCodeCoverage]
-    public override void Flush() => _stream.Flush();
+	public override int Read(byte[] buffer, int offset, int count)
+	{
+		return _stream.Read(buffer, offset, count);
+	}
 
-    [ExcludeFromCodeCoverage]
-    public override long Position
-    {
-        get => _stream.Position;
-        set => _stream.Position = value;
-    }
+	[ExcludeFromCodeCoverage]
+	public override long Seek(long offset, SeekOrigin origin)
+	{
+		return _stream.Seek(offset, origin);
+	}
 
-    public override int Read(byte[] buffer, int offset, int count) => _stream.Read(buffer, offset, count);
+	[ExcludeFromCodeCoverage]
+	public override void SetLength(long value)
+	{
+		_stream.SetLength(value);
+	}
 
-    [ExcludeFromCodeCoverage]
-    public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);
+	[ExcludeFromCodeCoverage]
+	public override void Write(byte[] buffer, int offset, int count)
+	{
+		_stream.Write(buffer, offset, count);
+	}
 
-    [ExcludeFromCodeCoverage]
-    public override void SetLength(long value) => _stream.SetLength(value);
+	protected override void Dispose(bool disposing)
+	{
+		_stream.Dispose();
+		_response.Dispose();
 
-    [ExcludeFromCodeCoverage]
-    public override void Write(byte[] buffer, int offset, int count) => _stream.Write(buffer, offset, count);
-
-    #endregion
+		base.Dispose(true);
+	}
 }

--- a/src/Storage/S3Upload.cs
+++ b/src/Storage/S3Upload.cs
@@ -6,94 +6,116 @@ namespace Storage;
 
 public sealed class S3Upload : IDisposable
 {
-    public readonly string FileName;
-    public readonly string UploadId;
+	private readonly S3Client _client;
+	private readonly string _encodedFileName;
+	private readonly string _fileName;
+	private readonly string _uploadId;
 
-    public long Written
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _written;
-    }
-    
-    private byte[]? _byteBuffer;
-    private readonly S3Client _client;
-    private readonly string _encodedFileName;
-    private bool _disposed;
-    private string[] _parts;
-    private int _partCount;
-    private long _written;
+	private byte[]? _byteBuffer;
+	private bool _disposed;
+	private int _partCount;
+	private string[] _parts;
 
-    internal S3Upload(S3Client client, string fileName, string encodedFileName, string uploadId)
-    {
-        FileName = fileName;
-        UploadId = uploadId;
+	internal S3Upload(S3Client client, string fileName, string encodedFileName, string uploadId)
+	{
+		_fileName = fileName;
+		_uploadId = uploadId;
 
-        _client = client;
-        _encodedFileName = encodedFileName;
-        _parts = ArrayPool<string>.Shared.Rent(16);
-    }
+		_client = client;
+		_encodedFileName = encodedFileName;
+		_parts = ArrayPool<string>.Shared.Rent(16);
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Task Abort(CancellationToken cancellation)
-    {
-        return _client.MultipartAbort(_encodedFileName, UploadId, cancellation);
-    }
+	public long Written
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get;
+		private set;
+	}
 
-    public Task<bool> Complete(CancellationToken cancellation) => _partCount == 0
-        ? Task.FromResult(false)
-        : _client.MultipartComplete(_encodedFileName, UploadId, _parts, _partCount, cancellation);
+	public void Dispose()
+	{
+		if (_disposed)
+		{
+			return;
+		}
 
-    public void Dispose()
-    {
-        if (_disposed) return;
+		Array.Clear(_parts, 0, _partCount);
+		ArrayPool<string>.Shared.Return(_parts);
+		_parts = null!;
 
-        Array.Clear(_parts, 0, _partCount);
-        ArrayPool<string>.Shared.Return(_parts);
-        _parts = null!;
+		if (_byteBuffer is not null)
+		{
+			ArrayPool<byte>.Shared.Return(_byteBuffer);
+			_byteBuffer = null;
+		}
 
-        if (_byteBuffer != null)
-        {
-            ArrayPool<byte>.Shared.Return(_byteBuffer);
-            _byteBuffer = null;
-        }
+		_disposed = true;
+	}
 
-        _disposed = true;
-    }
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public Task Abort(CancellationToken cancellation)
+	{
+		return _client.MultipartAbort(_encodedFileName, _uploadId, cancellation);
+	}
 
-    public Task<bool> Upload(Stream data, CancellationToken cancellation)
-    {
-        _byteBuffer ??= ArrayPool<byte>.Shared.Rent(S3Client.DefaultPartSize);
-        return Upload(data, _byteBuffer, cancellation);
-    }
+	public Task<bool> Complete(CancellationToken cancellation)
+	{
+		return _partCount == 0
+			? Task.FromResult(false)
+			: _client.MultipartComplete(_encodedFileName, _uploadId, _parts, _partCount, cancellation);
+	}
 
-    public async Task<bool> Upload(Stream data, byte[] buffer, CancellationToken cancellation)
-    {
-        while (true)
-        {
-            var written = await data.ReadTo(buffer, cancellation);
-            if (written == 0) break;
-            if (!await Upload(buffer, written, cancellation)) return false;
-        }
+	public Task<bool> Upload(Stream data, CancellationToken cancellation)
+	{
+		_byteBuffer ??= ArrayPool<byte>.Shared.Rent(S3Client.DefaultPartSize);
+		return Upload(data, _byteBuffer, cancellation);
+	}
 
-        return true;
-    }
+	public async Task<bool> Upload(Stream data, byte[] buffer, CancellationToken token)
+	{
+		while (true)
+		{
+			var written = await data.ReadTo(buffer, token);
+			if (written is 0)
+			{
+				break;
+			}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Task<bool> Upload(byte[] data, CancellationToken cancellation) => Upload(data, data.Length, cancellation);
+			if (!await Upload(buffer, written, token))
+			{
+				return false;
+			}
+		}
 
-    public async Task<bool> Upload(byte[] data, int length, CancellationToken cancellation)
-    {
-        var partId = await _client.MultipartUpload(
-            _encodedFileName, UploadId, _partCount + 1, data, length,
-            cancellation);
+		return true;
+	}
 
-        if (string.IsNullOrEmpty(partId)) return false;
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public Task<bool> Upload(byte[] data, CancellationToken cancellation)
+	{
+		return Upload(data, data.Length, cancellation);
+	}
 
-        if (_parts.Length == _partCount) CollectionUtils.Resize(ref _parts, ArrayPool<string>.Shared, _partCount * 2);
-        _parts[_partCount++] = partId;
+	public async Task<bool> Upload(byte[] data, int length, CancellationToken token)
+	{
+		var partId = await _client.MultipartUpload(
+			_encodedFileName, _uploadId, _partCount + 1, data, length, token);
 
-        _written += length;
-        
-        return true;
-    }
+		if (string.IsNullOrEmpty(partId))
+		{
+			return false;
+		}
+
+		if (_parts.Length == _partCount)
+		{
+			CollectionUtils.Resize(ref _parts, ArrayPool<string>.Shared, _partCount * 2);
+		}
+
+		_parts[_partCount++] = partId;
+
+		Written += length;
+
+		return true;
+	}
 }

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -40,6 +40,7 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="Storage.Tests" />
+		<InternalsVisibleTo Include="Storage.Benchmark" />
 		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
 	</ItemGroup>
 

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -38,4 +38,9 @@
       </PackageReference>
     </ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="Storage.Tests" />
+		<InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
+	</ItemGroup>
+
 </Project>

--- a/src/Storage/Storage.csproj
+++ b/src/Storage/Storage.csproj
@@ -20,6 +20,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+
     </PropertyGroup>
 
     <ItemGroup>
@@ -28,6 +29,13 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="Storage.Benchmark" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/src/Storage/Utils/Errors.cs
+++ b/src/Storage/Utils/Errors.cs
@@ -5,9 +5,10 @@ namespace Storage.Utils;
 internal static class Errors
 {
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void CantFormatToString<T>(T value) where T : struct
+    public static void CantFormatToString<T>(T value)
+	    where T : struct
     {
-        throw new Exception($"Can't format '{value}' to string");
+        throw new FormatException($"Can't format '{value}' to string");
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -15,7 +16,7 @@ internal static class Errors
     {
         throw new ObjectDisposedException(nameof(S3Client));
     }
-    
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void UnexpectedResult(HttpResponseMessage response)
     {

--- a/src/Storage/Utils/HashHelper.cs
+++ b/src/Storage/Utils/HashHelper.cs
@@ -25,7 +25,7 @@ internal static class HashHelper
     public static string ToHex(ReadOnlySpan<byte> data)
     {
         Span<char> buffer = stackalloc char[2];
-        var builder = new ValueStringBuilder(stackalloc char[64]);
+        using var builder = new ValueStringBuilder(stackalloc char[64]);
 
         foreach (var element in data)
         {
@@ -35,7 +35,7 @@ internal static class HashHelper
         return builder.Flush();
     }
 
-    [SuppressMessage("ReSharper", "InvertIf")]
+    [SuppressMessage("ReSharper", "InvertIf", Justification = "Approved")]
     private static string Sha256ToHex(ReadOnlySpan<char> value)
     {
         var count = Encoding.UTF8.GetByteCount(value);

--- a/src/Storage/Utils/HashHelper.cs
+++ b/src/Storage/Utils/HashHelper.cs
@@ -27,7 +27,7 @@ internal static class HashHelper
         Span<char> buffer = stackalloc char[2];
         using var builder = new ValueStringBuilder(stackalloc char[64]);
 
-        foreach (var element in data)
+        foreach (ref readonly var element in data)
         {
             builder.Append(buffer[..StringUtils.FormatX2(ref buffer, element)]);
         }

--- a/src/Storage/Utils/HttpHelper.cs
+++ b/src/Storage/Utils/HttpHelper.cs
@@ -5,101 +5,108 @@ namespace Storage.Utils;
 
 internal readonly struct HttpHelper
 {
-    public static readonly HashSet<char> ValidUrlCharacters =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~".ToHashSet();
+	private static readonly HashSet<char> _validUrlCharacters =
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~".ToHashSet();
 
-    public static bool AppendEncodedName(ref ValueStringBuilder builder, ReadOnlySpan<char> name)
-    {
-        var count = Encoding.UTF8.GetByteCount(name);
-        var hasEncoded = false;
+	private readonly string _headerEnd;
+	private readonly string _headerStart;
 
-        var pool = ArrayPool<byte>.Shared;
-        var byteBuffer = pool.Rent(count);
+	private readonly string _urlMiddle;
+	private readonly string _urlStart;
 
-        Span<char> charBuffer = stackalloc char[2];
-        Span<char> upperBuffer = stackalloc char[2];
+	public HttpHelper(string accessKey, string region, string service, string[] signedHeaders)
+	{
+		_headerStart = $"AWS4-HMAC-SHA256 Credential={accessKey}/";
+		_headerEnd = $"/{region}/{service}/aws4_request, SignedHeaders={string.Join(';', signedHeaders)}, Signature=";
 
-        var validCharacters = ValidUrlCharacters;
-        var encoded = Encoding.UTF8.GetBytes(name, byteBuffer);
+		_urlStart = $"?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential={accessKey}%2F";
+		_urlMiddle = $"%2F{region}%2F{service}%2Faws4_request";
+	}
 
-        foreach (char symbol in byteBuffer.AsSpan(0, encoded))
-        {
-            if (validCharacters.Contains(symbol))
-            {
-                builder.Append(symbol);
-            }
-            else
-            {
-                builder.Append('%');
+	public static bool AppendEncodedName(scoped ref ValueStringBuilder builder, ReadOnlySpan<char> name)
+	{
+		var count = Encoding.UTF8.GetByteCount(name);
+		var hasEncoded = false;
 
-                StringUtils.FormatX2(ref charBuffer, symbol);
-                MemoryExtensions.ToUpperInvariant(charBuffer, upperBuffer);
-                builder.Append(upperBuffer);
+		var pool = ArrayPool<byte>.Shared;
+		var byteBuffer = pool.Rent(count);
 
-                hasEncoded = true;
-            }
-        }
+		Span<char> charBuffer = stackalloc char[2];
+		Span<char> upperBuffer = stackalloc char[2];
 
-        return hasEncoded;
-    }
+		var validCharacters = _validUrlCharacters;
+		var encoded = Encoding.UTF8.GetBytes(name, byteBuffer);
 
-    public static string EncodeName(string fileName)
-    {
-        var builder = new ValueStringBuilder(stackalloc char[fileName.Length]);
-        var encoded = AppendEncodedName(ref builder, fileName);
+		try
+		{
+			foreach (char symbol in byteBuffer.AsSpan(0, encoded))
+			{
+				if (validCharacters.Contains(symbol))
+				{
+					builder.Append(symbol);
+				}
+				else
+				{
+					builder.Append('%');
 
-        return encoded
-            ? builder.Flush()
-            : fileName;
-    }
+					StringUtils.FormatX2(ref charBuffer, symbol);
+					MemoryExtensions.ToUpperInvariant(charBuffer, upperBuffer);
+					builder.Append(upperBuffer);
 
-    private readonly string _headerEnd;
-    private readonly string _headerStart;
+					hasEncoded = true;
+				}
+			}
 
-    private readonly string _urlMiddle;
-    private readonly string _urlStart;
+			return hasEncoded;
+		}
+		finally
+		{
+			pool.Return(byteBuffer);
+		}
+	}
 
-    public HttpHelper(string accessKey, string region, string service, string[] signedHeaders)
-    {
-        _headerStart = $"AWS4-HMAC-SHA256 Credential={accessKey}/";
-        _headerEnd = $"/{region}/{service}/aws4_request, SignedHeaders={string.Join(';', signedHeaders)}, Signature=";
+	public static string EncodeName(string fileName)
+	{
+		var builder = new ValueStringBuilder(stackalloc char[fileName.Length]);
+		var encoded = AppendEncodedName(ref builder, fileName);
 
-        _urlStart = $"?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential={accessKey}%2F";
-        _urlMiddle = $"%2F{region}%2F{service}%2Faws4_request";
-    }
+		return encoded
+			? builder.Flush()
+			: fileName;
+	}
 
-    public string BuildHeader(DateTime now, string signature)
-    {
-        var builder = new ValueStringBuilder(stackalloc char[512]);
+	public string BuildHeader(DateTime now, string signature)
+	{
+		using var builder = new ValueStringBuilder(stackalloc char[512]);
 
-        builder.Append(_headerStart);
-        builder.Append(now, Signature.Iso8601Date);
-        builder.Append(_headerEnd);
-        builder.Append(signature);
+		builder.Append(_headerStart);
+		builder.Append(now, Signature.Iso8601Date);
+		builder.Append(_headerEnd);
+		builder.Append(signature);
 
-        return builder.Flush();
-    }
+		return builder.Flush();
+	}
 
-    public string BuildUrl(string bucket, string fileName, DateTime now, TimeSpan expires)
-    {
-        var builder = new ValueStringBuilder(stackalloc char[512]);
+	public string BuildUrl(string bucket, string fileName, DateTime now, TimeSpan expires)
+	{
+		var builder = new ValueStringBuilder(stackalloc char[512]);
 
-        builder.Append(bucket);
-        builder.Append('/');
+		builder.Append(bucket);
+		builder.Append('/');
 
-        AppendEncodedName(ref builder, fileName);
+		AppendEncodedName(ref builder, fileName);
 
-        builder.Append(_urlStart);
-        builder.Append(now, Signature.Iso8601Date);
-        builder.Append(_urlMiddle);
+		builder.Append(_urlStart);
+		builder.Append(now, Signature.Iso8601Date);
+		builder.Append(_urlMiddle);
 
-        builder.Append("&X-Amz-Date=");
-        builder.Append(now, Signature.Iso8601DateTime);
-        builder.Append("&X-Amz-Expires=");
-        builder.Append(expires.TotalSeconds);
+		builder.Append("&X-Amz-Date=");
+		builder.Append(now, Signature.Iso8601DateTime);
+		builder.Append("&X-Amz-Expires=");
+		builder.Append(expires.TotalSeconds);
 
-        builder.Append($"&X-Amz-SignedHeaders=host");
+		builder.Append("&X-Amz-SignedHeaders=host");
 
-        return builder.Flush();
-    }
+		return builder.Flush();
+	}
 }

--- a/src/Storage/Utils/HttpHelper.cs
+++ b/src/Storage/Utils/HttpHelper.cs
@@ -39,9 +39,11 @@ internal readonly struct HttpHelper
 
 		try
 		{
-			foreach (ref readonly var symbol in byteBuffer.AsSpan(0, encoded))
+			var span = byteBuffer.AsSpan(0, encoded);
+			for (var index = 0; index < span.Length; index++)
 			{
-				if (validCharacters.Contains((char)symbol))
+				var symbol = (char)span[index];
+				if (validCharacters.Contains(symbol))
 				{
 					builder.Append(symbol);
 				}

--- a/src/Storage/Utils/HttpHelper.cs
+++ b/src/Storage/Utils/HttpHelper.cs
@@ -39,9 +39,9 @@ internal readonly struct HttpHelper
 
 		try
 		{
-			foreach (char symbol in byteBuffer.AsSpan(0, encoded))
+			foreach (ref readonly var symbol in byteBuffer.AsSpan(0, encoded))
 			{
-				if (validCharacters.Contains(symbol))
+				if (validCharacters.Contains((char)symbol))
 				{
 					builder.Append(symbol);
 				}

--- a/src/Storage/Utils/Signature.cs
+++ b/src/Storage/Utils/Signature.cs
@@ -28,7 +28,9 @@ internal sealed class Signature
 
     public string Calculate(
         HttpRequestMessage request,
-        string payloadHash, string[] signedHeaders, DateTime requestDate)
+        string payloadHash,
+        string[] signedHeaders,
+        DateTime requestDate)
     {
         var builder = new ValueStringBuilder(stackalloc char[512]);
 
@@ -61,8 +63,9 @@ internal sealed class Signature
     }
 
     private static void AppendCanonicalHeaders(
-        ref ValueStringBuilder builder,
-        HttpRequestMessage request, string[] signedHeaders)
+        scoped ref ValueStringBuilder builder,
+        HttpRequestMessage request,
+        string[] signedHeaders)
     {
         var sortedHeaders = Interlocked.Exchange(ref _headerSort, null) ?? new SortedDictionary<string, string>();
         foreach (var requestHeader in request.Headers)
@@ -99,21 +102,33 @@ internal sealed class Signature
         Interlocked.Exchange(ref _headerSort, sortedHeaders);
     }
 
-    private static void AppendCanonicalQueryParameters(ref ValueStringBuilder builder, string? query)
+    private static void AppendCanonicalQueryParameters(scoped ref ValueStringBuilder builder, string? query)
     {
-        if (string.IsNullOrEmpty(query) || query == "?") return;
+        if (string.IsNullOrEmpty(query) || query == "?")
+		{
+			return;
+		}
 
         var scanIndex = 0;
-        if (query[0] == '?') scanIndex = 1;
+        if (query[0] is '?')
+		{
+			scanIndex = 1;
+		}
 
         var textLength = query.Length;
         var equalIndex = query.IndexOf('=');
-        if (equalIndex == -1) equalIndex = textLength;
+        if (equalIndex is -1)
+		{
+			equalIndex = textLength;
+		}
 
         while (scanIndex < textLength)
         {
             var delimiter = query.IndexOf('&', scanIndex);
-            if (delimiter == -1) delimiter = textLength;
+            if (delimiter is -1)
+			{
+				delimiter = textLength;
+			}
 
             if (equalIndex < delimiter)
             {
@@ -131,8 +146,11 @@ internal sealed class Signature
                 builder.Append('&');
 
                 equalIndex = query.IndexOf('=', delimiter);
-                if (equalIndex == -1) equalIndex = textLength;
-            }
+                if (equalIndex is -1)
+				{
+					equalIndex = textLength;
+				}
+			}
             else
             {
                 if (delimiter > scanIndex)
@@ -151,8 +169,10 @@ internal sealed class Signature
     }
 
     private static void AppendCanonicalRequestHash(
-        ref ValueStringBuilder builder, HttpRequestMessage request,
-        string[] signedHeaders, string payload)
+	    scoped ref ValueStringBuilder builder,
+	    HttpRequestMessage request,
+	    string[] signedHeaders,
+	    string payload)
     {
         var canonical = new ValueStringBuilder(stackalloc char[512]);
         var uri = request.RequestUri!;
@@ -171,12 +191,20 @@ internal sealed class Signature
         canonical.Append(newLine);
 
         var first = true;
-        foreach (var header in signedHeaders)
+        var span = signedHeaders.AsSpan();
+        for (var index = 0; index < span.Length; index++)
         {
-            if (first) first = false;
-            else canonical.Append(';');
+	        var header = span[index];
+	        if (first)
+	        {
+		        first = false;
+	        }
+	        else
+	        {
+		        canonical.Append(';');
+	        }
 
-            canonical.Append(header);
+	        canonical.Append(header);
         }
 
         canonical.Append(newLine);
@@ -187,7 +215,7 @@ internal sealed class Signature
         canonical.Dispose();
     }
 
-    private static void AppendCanonicalRequestHash(ref ValueStringBuilder builder, string url)
+    private static void AppendCanonicalRequestHash(scoped ref ValueStringBuilder builder, string url)
     {
         var uri = new Uri(url);
 
@@ -228,48 +256,33 @@ internal sealed class Signature
         Span<byte> hashBuffer = stackalloc byte[32];
         if (SHA256.TryHashData(byteBuffer.AsSpan(0, encoded), hashBuffer, out var written))
         {
-            Span<char> buffer = stackalloc char[2];
-            foreach (var element in hashBuffer[..written])
-            {
-                builder.Append(buffer[..StringUtils.FormatX2(ref buffer, element)]);
-            }
+	        Span<char> buffer = stackalloc char[2];
+	        for (var index = 0; index < hashBuffer[..written].Length; index++)
+	        {
+		        var element = hashBuffer[..written][index];
+		        builder.Append(buffer[..StringUtils.FormatX2(ref buffer, element)]);
+	        }
         }
 
         pool.Return(byteBuffer);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void AppendStringToSign(ref ValueStringBuilder builder, DateTime requestDate)
-    {
-        builder.Append("AWS4-HMAC-SHA256\n");
-        builder.Append(requestDate, Iso8601DateTime);
-        builder.Append("\n");
-        builder.Append(requestDate, Iso8601Date);
-        builder.Append(_scope);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void CreateSigningKey(ref Span<byte> buffer, DateTime requestDate)
-    {
-        Span<char> dateBuffer = stackalloc char[16];
-
-        Sign(ref buffer, _secretKey, dateBuffer[..StringUtils.Format(ref dateBuffer, requestDate, Iso8601Date)]);
-        Sign(ref buffer, buffer, _region);
-        Sign(ref buffer, buffer, _service);
-        Sign(ref buffer, buffer, "aws4_request");
-    }
-
     private static string NormalizeHeader(string header)
     {
-        var builder = new ValueStringBuilder(stackalloc char[header.Length]);
+        using var builder = new ValueStringBuilder(stackalloc char[header.Length]);
         var culture = CultureInfo.InvariantCulture;
 
         // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
-        foreach (var ch in header)
+        var span = header.AsSpan();
+        for (var index = 0; index < span.Length; index++)
         {
-            if (ch == ' ') continue;
+	        var ch = span[index];
+	        if (ch is ' ')
+	        {
+		        continue;
+	        }
 
-            builder.Append(char.ToLower(ch, culture));
+	        builder.Append(char.ToLower(ch, culture));
         }
 
         return string.Intern(builder.Flush());
@@ -295,12 +308,34 @@ internal sealed class Signature
 
     private static string UnescapeString(ReadOnlySpan<char> query)
     {
-        var data = new ValueStringBuilder(stackalloc char[query.Length]);
-        foreach (var ch in query)
+        using var data = new ValueStringBuilder(stackalloc char[query.Length]);
+        for (var index = 0; index < query.Length; index++)
         {
-            data.Append(ch == '+' ? ' ' : ch);
+	        var ch = query[index];
+	        data.Append(ch is '+' ? ' ' : ch);
         }
 
         return Uri.UnescapeDataString(data.Flush());
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AppendStringToSign(ref ValueStringBuilder builder, DateTime requestDate)
+    {
+	    builder.Append("AWS4-HMAC-SHA256\n");
+	    builder.Append(requestDate, Iso8601DateTime);
+	    builder.Append("\n");
+	    builder.Append(requestDate, Iso8601Date);
+	    builder.Append(_scope);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CreateSigningKey(ref Span<byte> buffer, DateTime requestDate)
+    {
+	    Span<char> dateBuffer = stackalloc char[16];
+
+	    Sign(ref buffer, _secretKey, dateBuffer[..StringUtils.Format(ref dateBuffer, requestDate, Iso8601Date)]);
+	    Sign(ref buffer, buffer, _region);
+	    Sign(ref buffer, buffer, _service);
+	    Sign(ref buffer, buffer, "aws4_request");
     }
 }

--- a/src/Storage/Utils/StreamUtils.cs
+++ b/src/Storage/Utils/StreamUtils.cs
@@ -18,7 +18,8 @@ internal static class StreamUtils
 
             length -= written;
             offset += written;
-        } while (written > 0 && length > 0);
+        }
+        while (written > 0 && length > 0);
 
         return offset;
     }

--- a/src/Storage/Utils/StringUtils.cs
+++ b/src/Storage/Utils/StringUtils.cs
@@ -8,25 +8,30 @@ internal static class StringUtils
 {
     private static StringBuilder? _sharedBuilder;
 
-    #region Append
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static StringBuilder Append(this StringBuilder builder, string start, int middle, string end)
+    {
+	    return builder
+		    .Append(start)
+		    .Append(middle)
+		    .Append(end);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static StringBuilder Append(this StringBuilder builder, string start, int middle, string end) => builder
-        .Append(start)
-        .Append(middle)
-        .Append(end);
+    public static StringBuilder Append(this StringBuilder builder, string start, string middle, string end)
+    {
+	    return builder
+		    .Append(start)
+		    .Append(middle)
+		    .Append(end);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static StringBuilder Append(this StringBuilder builder, string start, string middle, string end) => builder
-        .Append(start)
-        .Append(middle)
-        .Append(end);
-
-    #endregion
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static StringBuilder GetBuilder() => Interlocked.Exchange(ref _sharedBuilder, null)
-                                                ?? new StringBuilder(4096);
+    public static StringBuilder GetBuilder()
+    {
+	    return Interlocked.Exchange(ref _sharedBuilder, null)
+	           ?? new StringBuilder(4096);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Format(ref Span<char> buffer, DateTime dateTime, string format)
@@ -47,7 +52,7 @@ internal static class StringUtils
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int FormatX2(ref Span<char> buffer, char value)
     {
-        return ((int) value).TryFormat(buffer, out var written, "x2", CultureInfo.InvariantCulture)
+        return ((int)value).TryFormat(buffer, out var written, "x2", CultureInfo.InvariantCulture)
             ? written
             : -1;
     }

--- a/src/Storage/Utils/XmlStreamReader.cs
+++ b/src/Storage/Utils/XmlStreamReader.cs
@@ -7,7 +7,7 @@ internal static class XmlStreamReader
         Span<char> buffer = stackalloc char[valueBufferLength];
 
         var written = ReadTo(stream, elementName, ref buffer);
-        return written == -1
+        return written is -1
             ? string.Empty
             : buffer[..written].ToString();
     }
@@ -21,16 +21,22 @@ internal static class XmlStreamReader
         while (true)
         {
             var nextByte = stream.ReadByte();
-            if (nextByte == -1) break;
+            if (nextByte is -1)
+			{
+				break;
+			}
 
-            var nextChar = (char) nextByte;
+            var nextChar = (char)nextByte;
             if (sectionStarted)
             {
                 if (nextChar == elementName[expectedIndex])
                 {
                     if (++expectedIndex == propertyLength)
                     {
-                        if ((char) stream.ReadByte() == '>') return ReadValue(stream, ref valueBuffer);
+                        if ((char)stream.ReadByte() is '>')
+						{
+							return ReadValue(stream, ref valueBuffer);
+						}
 
                         expectedIndex = 0;
                         sectionStarted = false;
@@ -44,8 +50,11 @@ internal static class XmlStreamReader
                 continue;
             }
 
-            if (nextChar == '<') sectionStarted = true;
-        }
+            if (nextChar is '<')
+			{
+				sectionStarted = true;
+			}
+		}
 
         return -1;
     }
@@ -56,10 +65,16 @@ internal static class XmlStreamReader
         while (true)
         {
             var nextByte = stream.ReadByte();
-            if (nextByte == -1) break;
+            if (nextByte is -1)
+			{
+				break;
+			}
 
-            var nextChar = (char) nextByte;
-            if (nextChar == '<') return index;
+            var nextChar = (char)nextByte;
+            if (nextChar is '<')
+			{
+				return index;
+			}
 
             valueBuffer[index++] = nextChar;
         }


### PR DESCRIPTION
Hello! Proposing refactoring and some tweaks:

- Added `StyleCop` to the project
- Aligned all code with `StyleCop`
- In cases of iteration `Span<T>`, changes cycles to `ref foreach`
- In `HttpHelper`, method `AppendEncodedName` added returning array to pool (`pool.Return(byteBuffer);`)
- Added in `Readme.md`  benchmarking results on `ARM` machine.

Tests:
<img width="546" alt="image" src="https://github.com/antomys/Storage/assets/50595040/690f24e2-4d72-4697-9f3c-1580db435272">